### PR TITLE
fix: ESM import errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
 	"exports": {
 		".": {
 			"types": "./dist/index.d.ts",
-			"svelte": "./dist/index.js"
+			"svelte": "./dist/index.js",
+			"import": "./dist/index.js"
 		}
 	},
 	"files": [

--- a/src/lib/Toast.svelte
+++ b/src/lib/Toast.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 import { createEventDispatcher, onDestroy, onMount } from "svelte";
-import type { ToastT, Position, HeightT } from "./types";
+import type { ToastT, Position, HeightT } from "./types.js";
 import Loader from "./Loader.svelte";
 import Icon from "./Icon.svelte";
-import { useEffect } from './state';
+import { useEffect } from './state.js';
 
 // Default lifetime of a toasts (in ms)
 const TOAST_LIFETIME = 4000

--- a/src/lib/Toaster.svelte
+++ b/src/lib/Toaster.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 import './styles.css'
 import { onMount } from "svelte";
-import type { HeightT, Position, ToastT, ToastToDismiss } from "./types";
-import { ToastState } from "./state";
+import type { HeightT, Position, ToastT, ToastToDismiss } from "./types.js";
+import { ToastState } from "./state.js";
 import Toast from "./Toast.svelte";
 
 // Visible toasts amount

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,7 +1,7 @@
 import Toaster from './Toaster.svelte'
 
-export { toast } from './state'
+export { toast } from './state.js'
 
 export { Toaster }
 
-export type { ToastT, ExternalToast } from './types'
+export type { ToastT, ExternalToast } from './types.js'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
 		"checkJs": true,
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
+		"moduleResolution": "NodeNext",
 		"resolveJsonModule": true,
 		"skipLibCheck": true,
 		"sourceMap": true,


### PR DESCRIPTION
this PR fixes ESM import errors

while vite might import this fine, the imports aren't defined correctly according to ESM spec, which will cause issues on things like esbuild, webpack and esm.sh

extensionless import is a TS thing, but when compiled to JS isn't valid
svelte export is nice for svelte, but causes errors when trying to resolve the module tree, so an import field is added