### PR TITLE
remove warning and info from `PromiseData`

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -9,7 +9,6 @@ export type PromiseT<Data = unknown> = Promise<Data> | (() => Promise<Data>)
 export type PromiseData<ToastData = unknown> = ExternalToast & {
   loading: string | ComponentType
   success: string | ComponentType | ((data: ToastData) => ComponentType | string)
-  info: string | ComponentType | ((data: ToastData) => ComponentType | string)
   error: string | ComponentType | ((error: unknown) => ComponentType | string)
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -10,6 +10,7 @@ export type PromiseData<ToastData = unknown> = ExternalToast & {
   loading: string | ComponentType
   success: string | ComponentType | ((data: ToastData) => ComponentType | string)
   info: string | ComponentType | ((data: ToastData) => ComponentType | string)
+  error: string | ComponentType | ((error: unknown) => ComponentType | string)
 }
 
 export interface ToastT {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -10,8 +10,6 @@ export type PromiseData<ToastData = unknown> = ExternalToast & {
   loading: string | ComponentType
   success: string | ComponentType | ((data: ToastData) => ComponentType | string)
   info: string | ComponentType | ((data: ToastData) => ComponentType | string)
-  warning: string | ComponentType | ((data: ToastData) => ComponentType | string)
-  error: string | ComponentType | ((error: unknown) => ComponentType | string)
 }
 
 export interface ToastT {


### PR DESCRIPTION
since `toast.promise` will only create `loading`, `success` and `error`:
https://github.com/wobsoriano/svelte-sonner/blob/0e09e6fabfc801ee1f23edb6cb0b8440fee3e164/src/lib/state.ts#L90-L101

so, I removed the `warning` and `info` from `PromiseData`.