### PR TITLE
fix: SSR security issues

### DIFF
--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -32,6 +32,15 @@ class Observer {
   }
 
   create = (data: ExternalToast & { message?: string | ComponentType; type?: ToastTypes; promise?: PromiseT }) => {
+    /**
+     * If we're not in the browser (e.g. in an SSR context), don't do
+     * anything. This ensures we aren't leaking data between requests with
+     * the same global `ToastState` instance.
+     * 
+     * @see https://kit.svelte.dev/docs/state-management
+     */
+    if (typeof document === 'undefined') return 
+
     const { message, ...rest } = data
     const id = typeof data?.id === 'number' || (data.id && data.id?.length > 0) ? data.id : toastsCounter++
 

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -1,5 +1,8 @@
 import { expect, test } from '@playwright/test';
 
+// Run tests in parallel as they are independent
+test.describe.configure({ mode: 'parallel' });
+
 test.beforeEach(async ({ page }) => {
   await page.goto('/')
 })


### PR DESCRIPTION
This PR addresses issues with using svelte-sonner in an SSR context, more specifically related to the global `ToastState` instance (see https://kit.svelte.dev/docs/state-management).

To ensure we're never writing to that instance on the server side, I've added a browser check to the `create` method on the `Observer`, returning `undefined` if we aren't in a browser context.

I also noticed the tests weren't running in parallel and taking 15+ seconds to run even though they are independent, so I added a line to the test file to speed up the CI pipeline as well. If you're interested, in the future I could get the project set up with solid unit tests with Vitest and Testing Library for Svelte to improve the coverage.
 
Closes: #26 