### PR TITLE
fix: add back missing duration prop to Toaster

### DIFF
--- a/.changeset/sour-yaks-destroy.md
+++ b/.changeset/sour-yaks-destroy.md
@@ -1,0 +1,5 @@
+---
+"svelte-sonner": patch
+---
+
+fix: add back missing duration prop to Toaster

--- a/src/lib/Toaster.svelte
+++ b/src/lib/Toaster.svelte
@@ -45,6 +45,7 @@
 	export let hotkey: string[] = ['altKey', 'KeyT'];
 	export let richColors = false;
 	export let expand = false;
+	export let duration: $$Props['duration'] = 4000;
 	export let visibleToasts = VISIBLE_TOASTS_AMOUNT;
 	export let closeButton = false;
 	export let toastOptions: ToastOptions = {};
@@ -216,7 +217,7 @@
 							''}
 						descriptionClass={toastOptions?.descriptionClass || ''}
 						classes={toastOptions.classes || {}}
-						duration={toastOptions.duration || 4000}
+						duration={toastOptions?.duration ?? duration}
 						unstyled={toastOptions.unstyled || false}
 					/>
 				{/each}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -133,6 +133,13 @@ export type ToasterProps = Partial<{
 	expand: boolean;
 
 	/**
+	 * The duration of the toast in milliseconds.
+	 *
+	 * @default 4000
+	 */
+	duration?: number;
+
+	/**
 	 * Amount of visible toasts
 	 *
 	 * @default 3
@@ -252,7 +259,7 @@ export type ToastProps = {
 	interacting: boolean;
 	cancelButtonStyle: string;
 	actionButtonStyle: string;
-	duration: number | null;
+	duration?: number;
 	descriptionClass: string;
 	classes: ToastClassnames;
 	unstyled: boolean;


### PR DESCRIPTION
To enhance the convenience of specifying a global `duration` prop other than `toastOptions.duration` in the <Toaster /> component, this PR reintroduces the previously removed property [here](https://github.com/wobsoriano/svelte-sonner/commit/93f282c6040b499564ef6f4d92a2834a3a09b552#diff-0fe79c63b875a6f66b16c4c089951eeb191d9a9f657fb008c4c5b3eb918e264aL53).

Closes https://github.com/wobsoriano/svelte-sonner/issues/50