### PR TITLE
fix: add css to prevent action button shrinking

### DIFF
--- a/.changeset/five-brooms-listen.md
+++ b/.changeset/five-brooms-listen.md
@@ -1,0 +1,5 @@
+---
+"svelte-sonner": patch
+---
+
+fix: prevent action button shrinking

--- a/src/lib/Toaster.svelte
+++ b/src/lib/Toaster.svelte
@@ -3,7 +3,7 @@
 	import type { Position, ToastOptions } from './types.js';
 	import { toastState } from './state.js';
 	import Toast from './Toast.svelte';
-	
+
 	import type { ToasterProps } from './types.js';
 
 	type $$Props = ToasterProps;

--- a/src/lib/Toaster.svelte
+++ b/src/lib/Toaster.svelte
@@ -3,7 +3,7 @@
 	import type { Position, ToastOptions } from './types.js';
 	import { toastState } from './state.js';
 	import Toast from './Toast.svelte';
-
+	
 	import type { ToasterProps } from './types.js';
 
 	type $$Props = ToasterProps;
@@ -408,6 +408,9 @@
 		border: none;
 		cursor: pointer;
 		outline: none;
+		display: flex;
+		align-items: center;
+		flex-shrink: 0;
 		transition:
 			opacity 400ms,
 			box-shadow 200ms;


### PR DESCRIPTION
Adds some [missing CSS](https://github.com/emilkowalski/sonner/blob/main/src/styles.css#L200-L202) to prevent the action button from shrinking.

Before:
![Screenshot 2024-02-07 075252](https://github.com/wobsoriano/svelte-sonner/assets/22429962/8187c92b-3b85-426a-a4ce-27c4da1a4e73)

After:
![Screenshot 2024-02-07 075120](https://github.com/wobsoriano/svelte-sonner/assets/22429962/7180502d-bb8a-47f3-9d20-abda6f722224)


Closes #53 