### PR TITLE
fix: toasts dismissing at the same time

### DIFF
--- a/.changeset/tiny-eagles-eat.md
+++ b/.changeset/tiny-eagles-eat.md
@@ -1,0 +1,5 @@
+---
+"svelte-sonner": patch
+---
+
+fix: toasts dismissing at the same time

--- a/src/lib/Toast.svelte
+++ b/src/lib/Toast.svelte
@@ -110,13 +110,7 @@
 
 	let remainingTime = toast.duration || duration || TOAST_LIFETIME;
 
-	let toastUpdateCount = 0;
-
-	$: if (toast) {
-		toastUpdateCount++;
-	}
-
-	$: if (toastUpdateCount > 1 && timeoutId) {
+	$: if (toast.updated) {
 		// if the toast has been updated after the initial render,
 		// we want to reset the timer and set the remaining time to the
 		// new duration

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -39,9 +39,12 @@ function createToastState() {
 			toasts.update((prev) =>
 				prev.map((toast) => {
 					if (toast.id === id) {
-						return { ...toast, ...data, id, title: message, dismissable, type };
+						return { ...toast, ...data, id, title: message, dismissable, type, updated: true };
 					}
-					return toast;
+					return {
+						...toast,
+						updated: false
+					};
 				})
 			);
 		} else {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -54,6 +54,10 @@ export type ToastT<T extends ComponentType = ComponentType> = {
 	descriptionClass?: string;
 	position?: Position;
 	unstyled?: boolean;
+	/**
+	 * @internal This is used to determine if the toast has been updated to determine when to reset timer. Hacky but works.
+	 */
+	updated?: boolean
 };
 
 export type Position =
@@ -84,7 +88,7 @@ export type ToastToDismiss = {
 
 export type ExternalToast<T extends ComponentType = ComponentType> = Omit<
 	ToastT<T>,
-	'id' | 'type' | 'title' | 'promise'
+	'id' | 'type' | 'title' | 'promise' | 'updated'
 > & {
 	id?: number | string;
 };


### PR DESCRIPTION
Fixes https://github.com/wobsoriano/svelte-sonner/issues/54

The current logic to check when a toast is updated reruns it when doing multiple toasts, making them dismiss at the same time. This PR adds a new property `updated`, setting it to `true`/`false` and running the same logic of resetting the timer.