### PR TITLE
feat: make icons customizable

### DIFF
--- a/.changeset/two-dancers-fetch.md
+++ b/.changeset/two-dancers-fetch.md
@@ -1,0 +1,5 @@
+---
+"svelte-sonner": patch
+---
+
+feat: make icons customizable

--- a/README.md
+++ b/README.md
@@ -268,6 +268,20 @@ Styling per toast type is also possible.
 />
 ```
 
+## Changing Icon
+
+You can change the default icons using slots:
+
+```svelte
+<Toaster>
+	<LoadingIcon slot="loading-icon" />
+	<SuccessIcon slot="success-icon" />
+	<ErrorIcon slot="error-icon" />
+	<InfoIcon slot="info-icon" />
+	<WarningIcon slot="warning-icon" />
+</Toaster>
+```
+
 ### Close button
 
 Add a close button to all toasts that shows on hover by adding the `closeButton` prop.

--- a/src/lib/Toast.svelte
+++ b/src/lib/Toast.svelte
@@ -1,8 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import type { ToastClassnames, ToastProps } from './types.js';
-	import Loader from './Loader.svelte';
-	import Icon from './Icon.svelte';
 	import { toastState, useEffect } from './state.js';
 	import { cn } from './internal/helpers.js';
 	import type { Expand } from './internal/types.js';
@@ -325,12 +323,20 @@
 		{#if toastType !== 'default' || toast.icon || toast.promise}
 			<div data-icon="">
 				{#if (toast.promise || toastType === 'loading') && !toast.icon}
-					<Loader visible={toastType === 'loading'} />
+					<slot name="loading-icon" />
 				{/if}
 				{#if toast.icon}
 					<svelte:component this={toast.icon}></svelte:component>
 				{:else}
-					<Icon type={toastType} />
+					{#if toastType === 'success'}
+						<slot name="success-icon" />
+					{:else if toastType === 'error'}
+						<slot name="error-icon" />
+					{:else if toastType === 'warning'}
+						<slot name="warning-icon" />
+					{:else if toastType === 'info'}
+						<slot name="info-icon" />
+					{/if}
 				{/if}
 			</div>
 		{/if}

--- a/src/lib/Toaster.svelte
+++ b/src/lib/Toaster.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
 	import { onDestroy, onMount } from 'svelte';
-	import type { Position, ToastOptions } from './types.js';
 	import { toastState } from './state.js';
 	import Toast from './Toast.svelte';
-
+	import Loader from './Loader.svelte';
+	import Icon from './Icon.svelte';
+	
 	import type { ToasterProps } from './types.js';
+	import type { Position, ToastOptions } from './types.js';
 
 	type $$Props = ToasterProps;
 
@@ -235,7 +237,23 @@
 						classes={toastOptions.classes || {}}
 						duration={toastOptions?.duration ?? duration}
 						unstyled={toastOptions.unstyled || false}
-					/>
+					>
+						<slot name="loading-icon" slot="loading-icon">
+							<Loader visible={toast.type === 'loading'} />
+						</slot>
+						<slot name="success-icon" slot="success-icon">
+							<Icon type="success" />
+						</slot>
+						<slot name="error-icon" slot="error-icon">
+							<Icon type="error" />
+						</slot>
+						<slot name="warning-icon" slot="warning-icon">
+							<Icon type="warning" />
+						</slot>
+						<slot name="info-icon" slot="info-icon">
+							<Icon type="info" />
+						</slot>
+					</Toast>
 				{/each}
 			</ol>
 		{/each}


### PR DESCRIPTION
This PR allows users to customize their icons via slots:

```svelte
<Toaster>
	<LoadingIcon slot="loading-icon" />
	<SuccessIcon slot="success-icon" />
	<ErrorIcon slot="error-icon" />
	<InfoIcon slot="info-icon" />
	<WarningIcon slot="warning-icon" />
</Toaster>
```