### PR TITLE
fix: height calculation for updated toasts

### DIFF
--- a/.changeset/long-seahorses-own.md
+++ b/.changeset/long-seahorses-own.md
@@ -1,0 +1,5 @@
+---
+"svelte-sonner": patch
+---
+
+fix: height calculation for updated toasts

--- a/src/lib/Toast.svelte
+++ b/src/lib/Toast.svelte
@@ -106,10 +106,16 @@
 
 		await tick();
 
+		let scale: number;
+		if (expanded || expandByDefault) {
+			scale = 1;
+		} else {
+			scale = 1 - index * SCALE_MULTIPLIER;
+		}
+
 		toastRef.style.setProperty('height', 'auto');
 
 		const offsetHeight = toastRef.offsetHeight;
-		const scale = 1 - index * SCALE_MULTIPLIER;
 		// rectHeight is affected by transform: scale(...);
 		const rectHeight = toastRef.getBoundingClientRect().height;
 		const scaledRectHeight =
@@ -318,7 +324,7 @@
 	style:--toasts-before={index}
 	style:--z-index={$toasts.length - index}
 	style:--offset={`${removed ? offsetBeforeRemove : offset}px`}
-	style:--initial-height={expandByDefault ? 'auto' : `${initialHeight}px`}
+	style:--initial-height={`${initialHeight}px`}
 	on:pointerdown={onPointerDown}
 	on:pointerup={onPointerUp}
 	on:pointermove={onPointerMove}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -25,7 +25,7 @@ export type PromiseData<ToastData = unknown> = ExternalToast & {
 export type ToastT<T extends ComponentType = ComponentType> = {
 	id: number | string;
 	title?: string | ComponentType;
-	type?: ToastTypes;
+	type: ToastTypes;
 	icon?: ComponentType;
 	component?: T;
 	componentProps?: ComponentProps<InstanceType<T>>;
@@ -57,7 +57,7 @@ export type ToastT<T extends ComponentType = ComponentType> = {
 	/**
 	 * @internal This is used to determine if the toast has been updated to determine when to reset timer. Hacky but works.
 	 */
-	updated?: boolean
+	updated?: boolean;
 };
 
 export type Position =


### PR DESCRIPTION
I am 95% sure this commit won't break anything, but someone should conduct additional testing.

This PR fixes height calculations for updated toasts.

Currently `updateHeights()` sets `height: auto` and gets the new height using `getBoundingClientRect()`.
Unfortunately, this takes `scale` into account, making the toast smaller than it should be. This is also an issue with the original react sonner.

You can see it (even on https://sonner.emilkowal.ski/) by clicking the "Promise" button and following it with a couple of presses of the "Default" button (Note: the Toaster needs to be collapsed).
![image](https://github.com/wobsoriano/svelte-sonner/assets/40291807/6fb931ee-67ce-4546-bfaa-4048dc61a03e)

I fixed it by taking scale into account during calculations. However, during testing, I learned that `getBoundingClientRect()` is also affected by transitions (e.g., scale transitioning from 0.90 to 0.85), so it's not reliable either. So I added another variable `offsetHeight`. Luckily, `element.offsetHeight` isn't affected by scale, but only returns integers, so it can be off by up to 1px.

The final code uses both calculations to provide the best possible experience.

You can test it for yourself by putting the following `console.log` in `updateHeights()`:
```
console.log(`scale: ${scale}\nscaledRectHeight: ${scaledRectHeight}\noffsetHeight: ${offsetHeight}\nchosen height: ${finalHeight}`);
```