### PR TITLE
fix: peer deps

### DIFF
--- a/.changeset/twenty-lemons-rhyme.md
+++ b/.changeset/twenty-lemons-rhyme.md
@@ -1,0 +1,5 @@
+---
+"svelte-sonner": patch
+---
+
+fix: Svelte 5 peer dep

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"!dist/**/*.spec.*"
 	],
 	"peerDependencies": {
-		"svelte": ">=3 <5"
+		"svelte": "^3.0.0 || ^4.0.0 || ^5.0.0-next.1"
 	},
 	"devDependencies": {
 		"@changesets/cli": "^2.27.1",


### PR DESCRIPTION
^5.0.0 works with pnpm, but not with npm. We must use -next.X. 