### PR TITLE
feat: add container aria label

### DIFF
--- a/.changeset/shaggy-hounds-learn.md
+++ b/.changeset/shaggy-hounds-learn.md
@@ -1,0 +1,5 @@
+---
+"svelte-sonner": patch
+---
+
+Add container aria label

--- a/.changeset/shaggy-hounds-learn.md
+++ b/.changeset/shaggy-hounds-learn.md
@@ -2,4 +2,4 @@
 "svelte-sonner": patch
 ---
 
-Add container aria label
+Add container aria label prop

--- a/src/lib/Toaster.svelte
+++ b/src/lib/Toaster.svelte
@@ -62,6 +62,7 @@
 	export let theme: Exclude<$$Props['theme'], undefined> = 'light';
 	export let position = 'bottom-right';
 	export let hotkey: string[] = ['altKey', 'KeyT'];
+	export let containerAriaLabel: string = 'Notifications';
 	export let richColors = false;
 	export let expand = false;
 	export let duration: Exclude<$$Props['duration'], undefined> = 4000;
@@ -214,7 +215,7 @@
 </script>
 
 {#if $toasts.length > 0}
-	<section aria-label={`Notifications ${hotkeyLabel}`} tabIndex={-1}>
+	<section aria-label={`${containerAriaLabel} ${hotkeyLabel}`} tabIndex={-1}>
 		{#each possiblePositions as position, index}
 			<ol
 				tabIndex={-1}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -184,6 +184,13 @@ export type ToasterProps = Partial<{
 	 * @default '14px'
 	 */
 	gap: number;
+
+	/**
+	 * Aria label to announce the notifications
+	 * @default 'Notifications'
+	 * 
+	 */
+	containerAriaLabel?: string
 }> &
 	HTMLOlAttributes;
 


### PR DESCRIPTION
Right now the container has a aria-label hardcoded, so it can't be modify to other languages.