### PR TITLE
chore: prep release workflow for `@next` release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
     push:
         branches:
             - main
+            - next
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 


### PR DESCRIPTION
This PR adds the `next` branch to the `release.yml` workflow so that it is in place. We can soon do a prerelease `@next` for the Svelte 5 version testing/usage prior to a full merge/release into `main`.

I'll create the `next` branch from the existing forked branch I have in this project and move those changes into it. I currently have `@next` deployments going for `bits-ui,` `form snap,` and `paneforge`, and changesets make it stupidly simple!