### PR TITLE
next: svelte 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,114 +4,114 @@
 
 ### Patch Changes
 
--   1836b26: Add license
+- 1836b26: Add license
 
 ## 0.3.25
 
 ### Patch Changes
 
--   a9e6f9c: fix: Svelte 5 peer dep
+- a9e6f9c: fix: Svelte 5 peer dep
 
 ## 0.3.24
 
 ### Patch Changes
 
--   52a09f2: fix: animate manually dismissed toasts
+- 52a09f2: fix: animate manually dismissed toasts
 
 ## 0.3.23
 
 ### Patch Changes
 
--   3903d66: feat: exported Icon and Loader component
--   771223b: fix: dark mode for close button
--   f031fa4: fix: safari 13 support for matchmedia event listener
+- 3903d66: feat: exported Icon and Loader component
+- 771223b: fix: dark mode for close button
+- f031fa4: fix: safari 13 support for matchmedia event listener
 
 ## 0.3.22
 
 ### Patch Changes
 
--   24fa4f2: fix: remove action button styling when unstyled is true
+- 24fa4f2: fix: remove action button styling when unstyled is true
 
 ## 0.3.21
 
 ### Patch Changes
 
--   65cb045: fix: height calculation for updated toasts
+- 65cb045: fix: height calculation for updated toasts
 
 ## 0.3.20
 
 ### Patch Changes
 
--   e3ec6c7: fix: blurry toasts, heights store
+- e3ec6c7: fix: blurry toasts, heights store
 
 ## 0.3.19
 
 ### Patch Changes
 
--   fee33b7: fix: multi-line promises height
+- fee33b7: fix: multi-line promises height
 
 ## 0.3.18
 
 ### Patch Changes
 
--   379d307: fix: blurry toasts
+- 379d307: fix: blurry toasts
 
 ## 0.3.17
 
 ### Patch Changes
 
--   074220c: feat: make icons customizable
+- 074220c: feat: make icons customizable
 
 ## 0.3.16
 
 ### Patch Changes
 
--   40b42e2: fix: rtl styling
+- 40b42e2: fix: rtl styling
 
 ## 0.3.15
 
 ### Patch Changes
 
--   26fc332: fix: toasts dismissing at the same time
+- 26fc332: fix: toasts dismissing at the same time
 
 ## 0.3.14
 
 ### Patch Changes
 
--   ea6f527: fix: class toast option not applied to toasts
+- ea6f527: fix: class toast option not applied to toasts
 
 ## 0.3.13
 
 ### Patch Changes
 
--   877e513: fix: prevent action button shrinking
+- 877e513: fix: prevent action button shrinking
 
 ## 0.3.12
 
 ### Patch Changes
 
--   6a59c2c: fix: add back missing duration prop to Toaster
+- 6a59c2c: fix: add back missing duration prop to Toaster
 
 ## 0.3.11
 
 ### Patch Changes
 
--   8c220f8: fix: toast dismissing immediately after update
+- 8c220f8: fix: toast dismissing immediately after update
 
 ## 0.3.10
 
 ### Patch Changes
 
--   23d87bc: Custom components properties propagation when it is used in toast of predefined types.
+- 23d87bc: Custom components properties propagation when it is used in toast of predefined types.
 
 ## 0.3.10
 
 ### Patch Changes
 
--   [#40](https://github.com/wobsoriano/svelte-sonner/pull/40): Custom components properties propagation when it is used in toast of predefined types.
+- [#40](https://github.com/wobsoriano/svelte-sonner/pull/40): Custom components properties propagation when it is used in toast of predefined types.
 
 ## 0.3.9
 
 ### Patch Changes
 
--   c997d85: fix: toasts being dismissed early & add `clientWritable`
+- c997d85: fix: toasts being dismissed early & add `clientWritable`

--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
 	"license": "MIT",
 	"author": "Robert Soriano <sorianorobertc@gmail.com>",
 	"homepage": "https://github.com/wobsoriano/svelte-sonner#readme",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/wobsoriano/svelte-sonner.git"
-  },
-  "bugs": "https://github.com/wobsoriano/svelte-sonner/issues",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/wobsoriano/svelte-sonner.git"
+	},
+	"bugs": "https://github.com/wobsoriano/svelte-sonner/issues",
 	"keywords": [
 		"svelte",
 		"toast"
@@ -47,8 +47,8 @@
 		"@changesets/cli": "^2.27.1",
 		"@playwright/test": "^1.38.0",
 		"@sveltejs/adapter-auto": "^3.3.1",
-		"@sveltejs/kit": "^2.7.3",
-		"@sveltejs/package": "^2.3.2",
+		"@sveltejs/kit": "^2.20.8",
+		"@sveltejs/package": "^2.3.11",
 		"@sveltejs/vite-plugin-svelte": "^4.0.0",
 		"@svitejs/changesets-changelog-github-compact": "^1.1.0",
 		"@testing-library/dom": "^10.3.1",
@@ -68,11 +68,11 @@
 		"highlight.js": "^11.8.0",
 		"jsdom": "^24.1.0",
 		"mode-watcher": "^0.4.1",
-		"prettier": "^3.2.5",
-		"prettier-plugin-svelte": "^3.2.7",
+		"prettier": "^3.5.3",
+		"prettier-plugin-svelte": "^3.3.3",
 		"publint": "^0.2.2",
-		"svelte": "^5.1.3",
-		"svelte-check": "^4.0.5",
+		"svelte": "^5.28.2",
+		"svelte-check": "^4.1.7",
 		"svelte-preprocess": "^6.0.3",
 		"tslib": "^2.8.0",
 		"typescript": "^5.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,16 +16,16 @@ importers:
         version: 1.38.0
       '@sveltejs/adapter-auto':
         specifier: ^3.3.1
-        version: 3.3.1(@sveltejs/kit@2.7.3(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.1.3)(vite@5.4.10(@types/node@20.10.5)(sass@1.67.0)))(svelte@5.1.3)(vite@5.4.10(@types/node@20.10.5)(sass@1.67.0)))
+        version: 3.3.1(@sveltejs/kit@2.20.8(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.28.2)(vite@5.4.10(@types/node@20.10.5)(sass@1.67.0)))(svelte@5.28.2)(vite@5.4.10(@types/node@20.10.5)(sass@1.67.0)))
       '@sveltejs/kit':
-        specifier: ^2.7.3
-        version: 2.7.3(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.1.3)(vite@5.4.10(@types/node@20.10.5)(sass@1.67.0)))(svelte@5.1.3)(vite@5.4.10(@types/node@20.10.5)(sass@1.67.0))
+        specifier: ^2.20.8
+        version: 2.20.8(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.28.2)(vite@5.4.10(@types/node@20.10.5)(sass@1.67.0)))(svelte@5.28.2)(vite@5.4.10(@types/node@20.10.5)(sass@1.67.0))
       '@sveltejs/package':
-        specifier: ^2.3.2
-        version: 2.3.2(svelte@5.1.3)(typescript@5.6.2)
+        specifier: ^2.3.11
+        version: 2.3.11(svelte@5.28.2)(typescript@5.6.2)
       '@sveltejs/vite-plugin-svelte':
         specifier: ^4.0.0
-        version: 4.0.0(svelte@5.1.3)(vite@5.4.10(@types/node@20.10.5)(sass@1.67.0))
+        version: 4.0.0(svelte@5.28.2)(vite@5.4.10(@types/node@20.10.5)(sass@1.67.0))
       '@svitejs/changesets-changelog-github-compact':
         specifier: ^1.1.0
         version: 1.1.0
@@ -37,7 +37,7 @@ importers:
         version: 6.4.6(@types/jest@29.5.11)(vitest@2.1.4(@types/node@20.10.5)(jsdom@24.1.0)(sass@1.67.0))
       '@testing-library/svelte':
         specifier: ^5.2.3
-        version: 5.2.3(svelte@5.1.3)(vite@5.4.10(@types/node@20.10.5)(sass@1.67.0))(vitest@2.1.4(@types/node@20.10.5)(jsdom@24.1.0)(sass@1.67.0))
+        version: 5.2.3(svelte@5.28.2)(vite@5.4.10(@types/node@20.10.5)(sass@1.67.0))(vitest@2.1.4(@types/node@20.10.5)(jsdom@24.1.0)(sass@1.67.0))
       '@testing-library/user-event':
         specifier: ^14.5.2
         version: 14.5.2(@testing-library/dom@10.3.1)
@@ -67,7 +67,7 @@ importers:
         version: 9.1.0(eslint@9.12.0)
       eslint-plugin-svelte:
         specifier: ^2.44.1
-        version: 2.44.1(eslint@9.12.0)(svelte@5.1.3)
+        version: 2.44.1(eslint@9.12.0)(svelte@5.28.2)
       globals:
         specifier: ^15.10.0
         version: 15.10.0
@@ -79,25 +79,25 @@ importers:
         version: 24.1.0
       mode-watcher:
         specifier: ^0.4.1
-        version: 0.4.1(svelte@5.1.3)
+        version: 0.4.1(svelte@5.28.2)
       prettier:
-        specifier: ^3.2.5
-        version: 3.3.3
+        specifier: ^3.5.3
+        version: 3.5.3
       prettier-plugin-svelte:
-        specifier: ^3.2.7
-        version: 3.2.7(prettier@3.3.3)(svelte@5.1.3)
+        specifier: ^3.3.3
+        version: 3.3.3(prettier@3.5.3)(svelte@5.28.2)
       publint:
         specifier: ^0.2.2
         version: 0.2.2
       svelte:
-        specifier: ^5.1.3
-        version: 5.1.3
+        specifier: ^5.28.2
+        version: 5.28.2
       svelte-check:
-        specifier: ^4.0.5
-        version: 4.0.5(svelte@5.1.3)(typescript@5.6.2)
+        specifier: ^4.1.7
+        version: 4.1.7(svelte@5.28.2)(typescript@5.6.2)
       svelte-preprocess:
         specifier: ^6.0.3
-        version: 6.0.3(postcss-load-config@3.1.4(postcss@8.4.47))(postcss@8.4.47)(sass@1.67.0)(svelte@5.1.3)(typescript@5.6.2)
+        version: 6.0.3(postcss-load-config@3.1.4(postcss@8.4.47))(postcss@8.4.47)(sass@1.67.0)(svelte@5.28.2)(typescript@5.6.2)
       tslib:
         specifier: ^2.8.0
         version: 2.8.0
@@ -526,22 +526,27 @@ packages:
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
 
+  '@sveltejs/acorn-typescript@1.0.5':
+    resolution: {integrity: sha512-IwQk4yfwLdibDlrXVE04jTZYlLnwsTT2PIOQQGNLWfjavGifnk1JD1LcZjZaBTRcxZu2FfPfNLOE04DSu9lqtQ==}
+    peerDependencies:
+      acorn: ^8.9.0
+
   '@sveltejs/adapter-auto@3.3.1':
     resolution: {integrity: sha512-5Sc7WAxYdL6q9j/+D0jJKjGREGlfIevDyHSQ2eNETHcB1TKlQWHcAo8AS8H1QdjNvSXpvOwNjykDUHPEAyGgdQ==}
     peerDependencies:
       '@sveltejs/kit': ^2.0.0
 
-  '@sveltejs/kit@2.7.3':
-    resolution: {integrity: sha512-Vx7nq5MJ86I8qXYsVidC5PX6xm+uxt8DydvOdmJoyOK7LvGP18OFEG359yY+aa51t6pENvqZAMqAREQQx1OI2Q==}
+  '@sveltejs/kit@2.20.8':
+    resolution: {integrity: sha512-ep9qTxL7WALhfm0kFecL3VHeuNew8IccbYGqv5TqL/KSqWRKzEgDG8blNlIu1CkLTTua/kHjI+f5T8eCmWIxKw==}
     engines: {node: '>=18.13'}
     hasBin: true
     peerDependencies:
-      '@sveltejs/vite-plugin-svelte': ^3.0.0 || ^4.0.0-next.1
+      '@sveltejs/vite-plugin-svelte': ^3.0.0 || ^4.0.0-next.1 || ^5.0.0
       svelte: ^4.0.0 || ^5.0.0-next.0
-      vite: ^5.0.3
+      vite: ^5.0.3 || ^6.0.0
 
-  '@sveltejs/package@2.3.2':
-    resolution: {integrity: sha512-6M8/Te7iXRG7SiH92wugqfyoJpuepjn78L433LnXicUeMso9M/N4vdL9DPK3MfTkVVY4klhNRptVqme3p4oZWA==}
+  '@sveltejs/package@2.3.11':
+    resolution: {integrity: sha512-DSMt2U0XNAdoQBYksrmgQi5dKy7jUTVDJLiagS/iXF7AShjAmTbGJQKruBuT/FfYAWvNxfQTSjkXU8eAIjVeNg==}
     engines: {node: ^16.14 || >=18}
     hasBin: true
     peerDependencies:
@@ -816,11 +821,6 @@ packages:
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  acorn-typescript@1.4.13:
-    resolution: {integrity: sha512-xsc9Xv0xlVfwp2o7sQ+GCQ1PgbkdcpWdTzrwXxO3xDMTAywVS3oXVOcOHuRjAPkS4P9b+yc/qNF15460v+jp4Q==}
-    peerDependencies:
-      acorn: '>=8.9.0'
-
   acorn@8.12.1:
     resolution: {integrity: sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==}
     engines: {node: '>=0.4.0'}
@@ -982,6 +982,10 @@ packages:
     resolution: {integrity: sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==}
     engines: {node: '>= 14.16.0'}
 
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
   ci-info@3.9.0:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
     engines: {node: '>=8'}
@@ -996,6 +1000,10 @@ packages:
   clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
     engines: {node: '>=0.8'}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
 
   color-convert@1.9.3:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
@@ -1239,8 +1247,8 @@ packages:
       jiti:
         optional: true
 
-  esm-env@1.0.0:
-    resolution: {integrity: sha512-Cf6VksWPsTuW01vU9Mk/3vRue91Zevka5SjyNf3nEpokFRuqt/KjUQoGAwq9qMmhpLTHmXzSIrFRw8zxWzmFBA==}
+  esm-env@1.2.2:
+    resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
 
   espree@10.2.0:
     resolution: {integrity: sha512-upbkBJbckcCNBDBDXEbuhjbP68n+scUd3k/U2EkyM9nw+I/jPiL4cLF/Al06CF96wRltFda16sxDFrxsI1v0/g==}
@@ -1259,8 +1267,8 @@ packages:
     resolution: {integrity: sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==}
     engines: {node: '>=0.10'}
 
-  esrap@1.2.2:
-    resolution: {integrity: sha512-F2pSJklxx1BlQIQgooczXCPHmcWpn6EsP5oo73LQfonG9fIlIENQ8vMmfGXeojP9MrkzUNAfyU5vdFlR9shHAw==}
+  esrap@1.4.6:
+    resolution: {integrity: sha512-F/D2mADJ9SHY3IwksD4DAXjTt7qt7GWUf3/8RhCNWmC/67tyb55dpimHmy7EplakFaflV0R/PC+fdSPqrRHAQw==}
 
   esrecurse@4.3.0:
     resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
@@ -1416,15 +1424,9 @@ packages:
     resolution: {integrity: sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==}
     engines: {node: '>= 0.4'}
 
-  globalyzer@0.1.0:
-    resolution: {integrity: sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==}
-
   globby@11.1.0:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
-
-  globrex@0.1.2:
-    resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
 
   gopd@1.0.1:
     resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
@@ -1598,8 +1600,8 @@ packages:
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
-  is-reference@3.0.2:
-    resolution: {integrity: sha512-v3rht/LgVcsdZa3O2Nqs+NMowLOxeOm7Ay9+/ARQ2F+qEoANRcqrjAZKGN0v8ymUetZGgkp26LTnGT7H0Qo9Pg==}
+  is-reference@3.0.3:
+    resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
 
   is-regex@1.1.4:
     resolution: {integrity: sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==}
@@ -2021,8 +2023,8 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
-  prettier-plugin-svelte@3.2.7:
-    resolution: {integrity: sha512-/Dswx/ea0lV34If1eDcG3nulQ63YNr5KPDfMsjbdtpSWOxKKJ7nAc2qlVuYwEvCr4raIuredNoR7K4JCkmTGaQ==}
+  prettier-plugin-svelte@3.3.3:
+    resolution: {integrity: sha512-yViK9zqQ+H2qZD1w/bH7W8i+bVfKrD8GIFjkFe4Thl6kCT9SlAsXVNmt3jCvQOCsnOhcvYgsoVlRV/Eu6x5nNw==}
     peerDependencies:
       prettier: ^3.0.0
       svelte: ^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0
@@ -2032,8 +2034,8 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
-  prettier@3.3.3:
-    resolution: {integrity: sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==}
+  prettier@3.5.3:
+    resolution: {integrity: sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -2308,8 +2310,8 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  svelte-check@4.0.5:
-    resolution: {integrity: sha512-icBTBZ3ibBaywbXUat3cK6hB5Du+Kq9Z8CRuyLmm64XIe2/r+lQcbuBx/IQgsbrC+kT2jQ0weVpZSSRIPwB6jQ==}
+  svelte-check@4.1.7:
+    resolution: {integrity: sha512-1jX4BzXrQJhC/Jt3SqYf6Ntu//vmfc6VWp07JkRfK2nn+22yIblspVUo96gzMkg0Zov8lQicxhxsMzOctwcMQQ==}
     engines: {node: '>= 18.0.0'}
     hasBin: true
     peerDependencies:
@@ -2362,14 +2364,14 @@ packages:
       typescript:
         optional: true
 
-  svelte2tsx@0.7.13:
-    resolution: {integrity: sha512-aObZ93/kGAiLXA/I/kP+x9FriZM+GboB/ReOIGmLNbVGEd2xC+aTCppm3mk1cc9I/z60VQf7b2QDxC3jOXu3yw==}
+  svelte2tsx@0.7.37:
+    resolution: {integrity: sha512-uQCWibXwUNPGQBGTZP1axIpFGFHTXXN30/ppodLVXCnX23U1nzEhqiVtFSEQjtUK3pFVxPhdnfyxD6ikxMCzPQ==}
     peerDependencies:
       svelte: ^3.55 || ^4.0.0-next.0 || ^4.0 || ^5.0.0-next.0
       typescript: ^4.9.4 || ^5.0.0
 
-  svelte@5.1.3:
-    resolution: {integrity: sha512-Sl8UFHlBvF54aK8MElFvyvaUfPE2REOz6LnhR2pBClCL11MU4qpn4V+KgAggaXxDyrP2iQixvHbtpHqL/zXlSQ==}
+  svelte@5.28.2:
+    resolution: {integrity: sha512-FbWBxgWOpQfhKvoGJv/TFwzqb4EhJbwCD17dB0tEpQiw1XyUEKZJtgm4nA4xq3LLsMo7hu5UY/BOFmroAxKTMg==}
     engines: {node: '>=18'}
 
   symbol-tree@3.2.4:
@@ -2381,9 +2383,6 @@ packages:
 
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
-
-  tiny-glob@0.2.9:
-    resolution: {integrity: sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -3131,18 +3130,22 @@ snapshots:
 
   '@sinclair/typebox@0.27.8': {}
 
-  '@sveltejs/adapter-auto@3.3.1(@sveltejs/kit@2.7.3(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.1.3)(vite@5.4.10(@types/node@20.10.5)(sass@1.67.0)))(svelte@5.1.3)(vite@5.4.10(@types/node@20.10.5)(sass@1.67.0)))':
+  '@sveltejs/acorn-typescript@1.0.5(acorn@8.12.1)':
     dependencies:
-      '@sveltejs/kit': 2.7.3(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.1.3)(vite@5.4.10(@types/node@20.10.5)(sass@1.67.0)))(svelte@5.1.3)(vite@5.4.10(@types/node@20.10.5)(sass@1.67.0))
+      acorn: 8.12.1
+
+  '@sveltejs/adapter-auto@3.3.1(@sveltejs/kit@2.20.8(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.28.2)(vite@5.4.10(@types/node@20.10.5)(sass@1.67.0)))(svelte@5.28.2)(vite@5.4.10(@types/node@20.10.5)(sass@1.67.0)))':
+    dependencies:
+      '@sveltejs/kit': 2.20.8(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.28.2)(vite@5.4.10(@types/node@20.10.5)(sass@1.67.0)))(svelte@5.28.2)(vite@5.4.10(@types/node@20.10.5)(sass@1.67.0))
       import-meta-resolve: 4.1.0
 
-  '@sveltejs/kit@2.7.3(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.1.3)(vite@5.4.10(@types/node@20.10.5)(sass@1.67.0)))(svelte@5.1.3)(vite@5.4.10(@types/node@20.10.5)(sass@1.67.0))':
+  '@sveltejs/kit@2.20.8(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.28.2)(vite@5.4.10(@types/node@20.10.5)(sass@1.67.0)))(svelte@5.28.2)(vite@5.4.10(@types/node@20.10.5)(sass@1.67.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 4.0.0(svelte@5.1.3)(vite@5.4.10(@types/node@20.10.5)(sass@1.67.0))
+      '@sveltejs/vite-plugin-svelte': 4.0.0(svelte@5.28.2)(vite@5.4.10(@types/node@20.10.5)(sass@1.67.0))
       '@types/cookie': 0.6.0
       cookie: 0.6.0
       devalue: 5.1.1
-      esm-env: 1.0.0
+      esm-env: 1.2.2
       import-meta-resolve: 4.1.0
       kleur: 4.1.5
       magic-string: 0.30.12
@@ -3150,38 +3153,37 @@ snapshots:
       sade: 1.8.1
       set-cookie-parser: 2.6.0
       sirv: 3.0.0
-      svelte: 5.1.3
-      tiny-glob: 0.2.9
+      svelte: 5.28.2
       vite: 5.4.10(@types/node@20.10.5)(sass@1.67.0)
 
-  '@sveltejs/package@2.3.2(svelte@5.1.3)(typescript@5.6.2)':
+  '@sveltejs/package@2.3.11(svelte@5.28.2)(typescript@5.6.2)':
     dependencies:
-      chokidar: 3.6.0
+      chokidar: 4.0.3
       kleur: 4.1.5
       sade: 1.8.1
       semver: 7.6.2
-      svelte: 5.1.3
-      svelte2tsx: 0.7.13(svelte@5.1.3)(typescript@5.6.2)
+      svelte: 5.28.2
+      svelte2tsx: 0.7.37(svelte@5.28.2)(typescript@5.6.2)
     transitivePeerDependencies:
       - typescript
 
-  '@sveltejs/vite-plugin-svelte-inspector@3.0.0-next.3(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.1.3)(vite@5.4.10(@types/node@20.10.5)(sass@1.67.0)))(svelte@5.1.3)(vite@5.4.10(@types/node@20.10.5)(sass@1.67.0))':
+  '@sveltejs/vite-plugin-svelte-inspector@3.0.0-next.3(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.28.2)(vite@5.4.10(@types/node@20.10.5)(sass@1.67.0)))(svelte@5.28.2)(vite@5.4.10(@types/node@20.10.5)(sass@1.67.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 4.0.0(svelte@5.1.3)(vite@5.4.10(@types/node@20.10.5)(sass@1.67.0))
+      '@sveltejs/vite-plugin-svelte': 4.0.0(svelte@5.28.2)(vite@5.4.10(@types/node@20.10.5)(sass@1.67.0))
       debug: 4.3.7
-      svelte: 5.1.3
+      svelte: 5.28.2
       vite: 5.4.10(@types/node@20.10.5)(sass@1.67.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.1.3)(vite@5.4.10(@types/node@20.10.5)(sass@1.67.0))':
+  '@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.28.2)(vite@5.4.10(@types/node@20.10.5)(sass@1.67.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 3.0.0-next.3(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.1.3)(vite@5.4.10(@types/node@20.10.5)(sass@1.67.0)))(svelte@5.1.3)(vite@5.4.10(@types/node@20.10.5)(sass@1.67.0))
+      '@sveltejs/vite-plugin-svelte-inspector': 3.0.0-next.3(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.28.2)(vite@5.4.10(@types/node@20.10.5)(sass@1.67.0)))(svelte@5.28.2)(vite@5.4.10(@types/node@20.10.5)(sass@1.67.0))
       debug: 4.3.7
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.12
-      svelte: 5.1.3
+      svelte: 5.28.2
       vite: 5.4.10(@types/node@20.10.5)(sass@1.67.0)
       vitefu: 1.0.3(vite@5.4.10(@types/node@20.10.5)(sass@1.67.0))
     transitivePeerDependencies:
@@ -3219,10 +3221,10 @@ snapshots:
       '@types/jest': 29.5.11
       vitest: 2.1.4(@types/node@20.10.5)(jsdom@24.1.0)(sass@1.67.0)
 
-  '@testing-library/svelte@5.2.3(svelte@5.1.3)(vite@5.4.10(@types/node@20.10.5)(sass@1.67.0))(vitest@2.1.4(@types/node@20.10.5)(jsdom@24.1.0)(sass@1.67.0))':
+  '@testing-library/svelte@5.2.3(svelte@5.28.2)(vite@5.4.10(@types/node@20.10.5)(sass@1.67.0))(vitest@2.1.4(@types/node@20.10.5)(jsdom@24.1.0)(sass@1.67.0))':
     dependencies:
       '@testing-library/dom': 10.3.1
-      svelte: 5.1.3
+      svelte: 5.28.2
     optionalDependencies:
       vite: 5.4.10(@types/node@20.10.5)(sass@1.67.0)
       vitest: 2.1.4(@types/node@20.10.5)(jsdom@24.1.0)(sass@1.67.0)
@@ -3498,10 +3500,6 @@ snapshots:
     dependencies:
       acorn: 8.12.1
 
-  acorn-typescript@1.4.13(acorn@8.12.1):
-    dependencies:
-      acorn: 8.12.1
-
   acorn@8.12.1: {}
 
   agent-base@7.1.1:
@@ -3535,6 +3533,7 @@ snapshots:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.1
+    optional: true
 
   argparse@1.0.10:
     dependencies:
@@ -3590,7 +3589,8 @@ snapshots:
     dependencies:
       is-windows: 1.0.2
 
-  binary-extensions@2.2.0: {}
+  binary-extensions@2.2.0:
+    optional: true
 
   brace-expansion@1.1.11:
     dependencies:
@@ -3666,8 +3666,13 @@ snapshots:
       readdirp: 3.6.0
     optionalDependencies:
       fsevents: 2.3.3
+    optional: true
 
   chokidar@4.0.1:
+    dependencies:
+      readdirp: 4.0.2
+
+  chokidar@4.0.3:
     dependencies:
       readdirp: 4.0.2
 
@@ -3686,6 +3691,8 @@ snapshots:
       wrap-ansi: 7.0.0
 
   clone@1.0.4: {}
+
+  clsx@2.1.1: {}
 
   color-convert@1.9.3:
     dependencies:
@@ -3922,7 +3929,7 @@ snapshots:
     dependencies:
       eslint: 9.12.0
 
-  eslint-plugin-svelte@2.44.1(eslint@9.12.0)(svelte@5.1.3):
+  eslint-plugin-svelte@2.44.1(eslint@9.12.0)(svelte@5.28.2):
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@9.12.0)
       '@jridgewell/sourcemap-codec': 1.5.0
@@ -3935,9 +3942,9 @@ snapshots:
       postcss-safe-parser: 6.0.0(postcss@8.4.47)
       postcss-selector-parser: 6.1.1
       semver: 7.6.2
-      svelte-eslint-parser: 0.41.1(svelte@5.1.3)
+      svelte-eslint-parser: 0.41.1(svelte@5.28.2)
     optionalDependencies:
-      svelte: 5.1.3
+      svelte: 5.28.2
     transitivePeerDependencies:
       - ts-node
 
@@ -3995,7 +4002,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  esm-env@1.0.0: {}
+  esm-env@1.2.2: {}
 
   espree@10.2.0:
     dependencies:
@@ -4015,10 +4022,9 @@ snapshots:
     dependencies:
       estraverse: 5.3.0
 
-  esrap@1.2.2:
+  esrap@1.4.6:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
-      '@types/estree': 1.0.6
 
   esrecurse@4.3.0:
     dependencies:
@@ -4179,8 +4185,6 @@ snapshots:
     dependencies:
       define-properties: 1.2.1
 
-  globalyzer@0.1.0: {}
-
   globby@11.1.0:
     dependencies:
       array-union: 2.1.0
@@ -4189,8 +4193,6 @@ snapshots:
       ignore: 5.3.2
       merge2: 1.4.1
       slash: 3.0.0
-
-  globrex@0.1.2: {}
 
   gopd@1.0.1:
     dependencies:
@@ -4306,6 +4308,7 @@ snapshots:
   is-binary-path@2.1.0:
     dependencies:
       binary-extensions: 2.2.0
+    optional: true
 
   is-boolean-object@1.1.2:
     dependencies:
@@ -4342,7 +4345,7 @@ snapshots:
 
   is-potential-custom-element-name@1.0.1: {}
 
-  is-reference@3.0.2:
+  is-reference@3.0.3:
     dependencies:
       '@types/estree': 1.0.6
 
@@ -4581,9 +4584,9 @@ snapshots:
 
   mixme@0.5.10: {}
 
-  mode-watcher@0.4.1(svelte@5.1.3):
+  mode-watcher@0.4.1(svelte@5.28.2):
     dependencies:
-      svelte: 5.1.3
+      svelte: 5.28.2
 
   mri@1.2.0: {}
 
@@ -4611,7 +4614,8 @@ snapshots:
       semver: 5.7.2
       validate-npm-package-license: 3.0.4
 
-  normalize-path@3.0.0: {}
+  normalize-path@3.0.0:
+    optional: true
 
   npm-bundled@2.0.1:
     dependencies:
@@ -4765,14 +4769,14 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier-plugin-svelte@3.2.7(prettier@3.3.3)(svelte@5.1.3):
+  prettier-plugin-svelte@3.3.3(prettier@3.5.3)(svelte@5.28.2):
     dependencies:
-      prettier: 3.3.3
-      svelte: 5.1.3
+      prettier: 3.5.3
+      svelte: 5.28.2
 
   prettier@2.8.8: {}
 
-  prettier@3.3.3: {}
+  prettier@3.5.3: {}
 
   pretty-format@27.5.1:
     dependencies:
@@ -4831,6 +4835,7 @@ snapshots:
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.1
+    optional: true
 
   readdirp@4.0.2: {}
 
@@ -5066,19 +5071,19 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte-check@4.0.5(svelte@5.1.3)(typescript@5.6.2):
+  svelte-check@4.1.7(svelte@5.28.2)(typescript@5.6.2):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       chokidar: 4.0.1
       fdir: 6.4.0
       picocolors: 1.1.0
       sade: 1.8.1
-      svelte: 5.1.3
+      svelte: 5.28.2
       typescript: 5.6.2
     transitivePeerDependencies:
       - picomatch
 
-  svelte-eslint-parser@0.41.1(svelte@5.1.3):
+  svelte-eslint-parser@0.41.1(svelte@5.28.2):
     dependencies:
       eslint-scope: 7.2.2
       eslint-visitor-keys: 3.4.3
@@ -5086,36 +5091,37 @@ snapshots:
       postcss: 8.4.47
       postcss-scss: 4.0.9(postcss@8.4.47)
     optionalDependencies:
-      svelte: 5.1.3
+      svelte: 5.28.2
 
-  svelte-preprocess@6.0.3(postcss-load-config@3.1.4(postcss@8.4.47))(postcss@8.4.47)(sass@1.67.0)(svelte@5.1.3)(typescript@5.6.2):
+  svelte-preprocess@6.0.3(postcss-load-config@3.1.4(postcss@8.4.47))(postcss@8.4.47)(sass@1.67.0)(svelte@5.28.2)(typescript@5.6.2):
     dependencies:
-      svelte: 5.1.3
+      svelte: 5.28.2
     optionalDependencies:
       postcss: 8.4.47
       postcss-load-config: 3.1.4(postcss@8.4.47)
       sass: 1.67.0
       typescript: 5.6.2
 
-  svelte2tsx@0.7.13(svelte@5.1.3)(typescript@5.6.2):
+  svelte2tsx@0.7.37(svelte@5.28.2)(typescript@5.6.2):
     dependencies:
       dedent-js: 1.0.1
       pascal-case: 3.1.2
-      svelte: 5.1.3
+      svelte: 5.28.2
       typescript: 5.6.2
 
-  svelte@5.1.3:
+  svelte@5.28.2:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@jridgewell/sourcemap-codec': 1.5.0
+      '@sveltejs/acorn-typescript': 1.0.5(acorn@8.12.1)
       '@types/estree': 1.0.6
       acorn: 8.12.1
-      acorn-typescript: 1.4.13(acorn@8.12.1)
       aria-query: 5.3.2
       axobject-query: 4.1.0
-      esm-env: 1.0.0
-      esrap: 1.2.2
-      is-reference: 3.0.2
+      clsx: 2.1.1
+      esm-env: 1.2.2
+      esrap: 1.4.6
+      is-reference: 3.0.3
       locate-character: 3.0.0
       magic-string: 0.30.12
       zimmerframe: 1.1.2
@@ -5125,11 +5131,6 @@ snapshots:
   term-size@2.2.1: {}
 
   text-table@0.2.0: {}
-
-  tiny-glob@0.2.9:
-    dependencies:
-      globalyzer: 0.1.0
-      globrex: 0.1.2
 
   tinybench@2.9.0: {}
 

--- a/src/components/Other.svelte
+++ b/src/components/Other.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { toast } from '$lib/index.js';
-	import type { Component } from 'svelte';
 	import CodeBlock from './CodeBlock.svelte';
 	import Test from './Test.svelte';
 	import TestWithProps from './TestWithProps.svelte';
@@ -71,7 +70,7 @@
   })
   `,
 			action: () => {
-				toast.custom(Test as unknown as Component, {
+				toast.custom(Test, {
 					componentProps: {
 						eventName: 'hello'
 					}
@@ -89,7 +88,6 @@
   })
   `,
 			action: () => {
-				// @ts-expect-error - TODO figure this out
 				toast.warning(TestWithProps, {
 					componentProps: {
 						message: 'This is <br />multiline message'

--- a/src/components/Other.svelte
+++ b/src/components/Other.svelte
@@ -89,7 +89,8 @@
   })
   `,
 			action: () => {
-				toast.warning(TestWithProps as unknown as Component, {
+				// @ts-expect-error - TODO figure this out
+				toast.warning(TestWithProps, {
 					componentProps: {
 						message: 'This is <br />multiline message'
 					}

--- a/src/lib/Toaster.svelte
+++ b/src/lib/Toaster.svelte
@@ -665,15 +665,15 @@
 	}
 
 	:where(
-			[data-sonner-toast][data-removed='true'][data-front='true'][data-swipe-out='false']
-		) {
+		[data-sonner-toast][data-removed='true'][data-front='true'][data-swipe-out='false']
+	) {
 		--y: translateY(calc(var(--lift) * -100%));
 		opacity: 0;
 	}
 
 	:where(
-			[data-sonner-toast][data-removed='true'][data-front='false'][data-swipe-out='false'][data-expanded='true']
-		) {
+		[data-sonner-toast][data-removed='true'][data-front='false'][data-swipe-out='false'][data-expanded='true']
+	) {
 		--y: translateY(
 			calc(var(--lift) * var(--offset) + var(--lift) * -100%)
 		);
@@ -681,8 +681,8 @@
 	}
 
 	:where(
-			[data-sonner-toast][data-removed='true'][data-front='false'][data-swipe-out='false'][data-expanded='false']
-		) {
+		[data-sonner-toast][data-removed='true'][data-front='false'][data-swipe-out='false'][data-expanded='false']
+	) {
 		--y: translateY(40%);
 		opacity: 0;
 		transition:

--- a/src/lib/toast-state.svelte.ts
+++ b/src/lib/toast-state.svelte.ts
@@ -41,9 +41,9 @@ class ToastState {
 		};
 	};
 
-	create = (
-		data: ExternalToast & {
-			message?: string | Component;
+	create = <T extends Component>(
+		data: ExternalToast<T> & {
+			message?: string | T;
 			type?: ToastTypes;
 			promise?: PromiseT;
 		}
@@ -95,30 +95,39 @@ class ToastState {
 		return id;
 	};
 
-	message = (message: string | Component, data?: ExternalToast) => {
-		return this.create({ ...data, type: 'default', message });
+	message = <T extends Component>(message: string | T, data?: ExternalToast<T>) => {
+		return this.create<T>({ ...data, type: 'default', message });
 	};
 
-	error = (message: string | Component, data?: ExternalToast): string | number => {
+	error = <T extends Component>(
+		message: string | T,
+		data?: ExternalToast<T>
+	): string | number => {
 		return this.create({ ...data, type: 'error', message });
 	};
 
-	success = (message: string | Component, data?: ExternalToast): string | number => {
+	success = <T extends Component>(
+		message: string | T,
+		data?: ExternalToast<T>
+	): string | number => {
 		return this.create({ ...data, type: 'success', message });
 	};
 
-	info = (message: string | Component, data?: ExternalToast): string | number => {
+	info = <T extends Component>(message: string | T, data?: ExternalToast<T>): string | number => {
 		return this.create({ ...data, type: 'info', message });
 	};
 
-	warning = <T extends Component = Component>(
+	warning = <T extends Component>(
 		message: string | T,
 		data?: ExternalToast<T>
 	): string | number => {
 		return this.create({ ...data, type: 'warning', message });
 	};
 
-	loading = (message: string | Component, data?: ExternalToast): string | number => {
+	loading = <T extends Component>(
+		message: string | T,
+		data?: ExternalToast<T>
+	): string | number => {
 		return this.create({ ...data, type: 'loading', message });
 	};
 
@@ -136,7 +145,7 @@ class ToastState {
 				...data,
 				promise,
 				type: 'loading',
-				message: data.loading
+				message: typeof data.loading === 'string' ? data.loading : data.loading()
 			});
 		}
 
@@ -145,7 +154,6 @@ class ToastState {
 		let shouldDismiss = id !== undefined;
 
 		p.then((response) => {
-			// TODO: Cleanup TS here, res has incorrect type
 			if (
 				typeof response === 'object' &&
 				response &&
@@ -185,10 +193,7 @@ class ToastState {
 		return id;
 	};
 
-	custom = <T extends Component = Component>(
-		component: T,
-		data?: ExternalToast<T>
-	): string | number => {
+	custom = <T extends Component>(component: T, data?: ExternalToast<T>): string | number => {
 		const id = data?.id || toastsCounter++;
 
 		this.create({ component, id, ...data });

--- a/src/lib/toast-state.svelte.ts
+++ b/src/lib/toast-state.svelte.ts
@@ -1,6 +1,13 @@
-import type { Component } from 'svelte';
 import { isBrowser } from './internal/helpers.js';
-import type { ExternalToast, HeightT, PromiseData, PromiseT, ToastT, ToastTypes } from './types.js';
+import type {
+	ExternalToast,
+	HeightT,
+	PromiseData,
+	PromiseT,
+	AnyComponent,
+	ToastT,
+	ToastTypes
+} from './types.js';
 
 let toastsCounter = 0;
 
@@ -8,7 +15,7 @@ type UpdateToastProps = {
 	id: number | string;
 	data: Partial<ToastT>;
 	type: ToastTypes;
-	message: string | Component | undefined;
+	message: string | AnyComponent | undefined;
 	dismissable: boolean;
 };
 
@@ -41,7 +48,7 @@ class ToastState {
 		};
 	};
 
-	create = <T extends Component>(
+	create = <T extends AnyComponent>(
 		data: ExternalToast<T> & {
 			message?: string | T;
 			type?: ToastTypes;
@@ -95,36 +102,39 @@ class ToastState {
 		return id;
 	};
 
-	message = <T extends Component>(message: string | T, data?: ExternalToast<T>) => {
+	message = <T extends AnyComponent>(message: string | T, data?: ExternalToast<T>) => {
 		return this.create<T>({ ...data, type: 'default', message });
 	};
 
-	error = <T extends Component>(
+	error = <T extends AnyComponent>(
 		message: string | T,
 		data?: ExternalToast<T>
 	): string | number => {
 		return this.create({ ...data, type: 'error', message });
 	};
 
-	success = <T extends Component>(
+	success = <T extends AnyComponent>(
 		message: string | T,
 		data?: ExternalToast<T>
 	): string | number => {
 		return this.create({ ...data, type: 'success', message });
 	};
 
-	info = <T extends Component>(message: string | T, data?: ExternalToast<T>): string | number => {
+	info = <T extends AnyComponent>(
+		message: string | T,
+		data?: ExternalToast<T>
+	): string | number => {
 		return this.create({ ...data, type: 'info', message });
 	};
 
-	warning = <T extends Component>(
+	warning = <T extends AnyComponent>(
 		message: string | T,
 		data?: ExternalToast<T>
 	): string | number => {
 		return this.create({ ...data, type: 'warning', message });
 	};
 
-	loading = <T extends Component>(
+	loading = <T extends AnyComponent>(
 		message: string | T,
 		data?: ExternalToast<T>
 	): string | number => {
@@ -193,7 +203,7 @@ class ToastState {
 		return id;
 	};
 
-	custom = <T extends Component>(component: T, data?: ExternalToast<T>): string | number => {
+	custom = <T extends AnyComponent>(component: T, data?: ExternalToast<T>): string | number => {
 		const id = data?.id || toastsCounter++;
 
 		this.create({ component, id, ...data });
@@ -229,7 +239,7 @@ function constructPromiseErrorMessage(response: unknown) {
 
 export const toastState = new ToastState();
 
-function toastFunction<T extends Component>(message: string | T, data?: ExternalToast<T>) {
+function toastFunction<T extends AnyComponent>(message: string | T, data?: ExternalToast<T>) {
 	return toastState.create({
 		message,
 		...data

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -4,6 +4,10 @@ import type { HTMLAttributes, HTMLOlAttributes } from 'svelte/elements';
 
 export type FixMe = unknown;
 
+// We need this to consistently be this wide.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type AnyComponent = Component<any, any, string>;
+
 export type ToastTypes =
 	| 'action'
 	| 'success'
@@ -20,32 +24,32 @@ export type PromiseData<ToastData = unknown> = ExternalToast & {
 	 * The loading message or a function that returns the message or
 	 * a custom toast component.
 	 */
-	loading?: string | (() => Component | string);
+	loading?: string | (() => AnyComponent | string);
 	/**
 	 * The success message or a function that returns the message or
 	 * a custom toast component.
 	 */
-	success?: string | ((data: ToastData) => Component | string);
+	success?: string | ((data: ToastData) => AnyComponent | string);
 	/**
 	 * The error message or a function that returns the message or
 	 * a custom toast component.
 	 */
-	error?: string | ((error: unknown) => Component | string);
+	error?: string | ((error: unknown) => AnyComponent | string);
 	/**
 	 * A function that is called when the promise is finally resolved or rejected.
 	 */
 	finally?: () => void | Promise<void>;
 };
 
-export type ToastT<T extends Component = Component> = {
+export type ToastT<T extends AnyComponent = AnyComponent> = {
 	id: number | string;
-	title?: string | Component;
+	title?: string | AnyComponent;
 	type: ToastTypes;
-	icon?: Component;
-	component?: Component;
+	icon?: AnyComponent;
+	component?: AnyComponent;
 	componentProps?: ComponentProps<T>;
 	invert?: boolean;
-	description?: string | Component;
+	description?: string | AnyComponent;
 	cancelButtonStyle?: string;
 	actionButtonStyle?: string;
 	duration?: number;
@@ -96,7 +100,7 @@ export type ToastToDismiss = {
 	dismiss: boolean;
 };
 
-export type ExternalToast<T extends Component = Component> = Omit<
+export type ExternalToast<T extends AnyComponent = AnyComponent> = Omit<
 	ToastT<T>,
 	'id' | 'type' | 'title' | 'promise' | 'updated'
 > & {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,4 @@
-import type { Component, Snippet } from 'svelte';
+import type { Component, ComponentProps, Snippet } from 'svelte';
 import type { Expand } from '$lib/internal/types.js';
 import type { HTMLAttributes, HTMLOlAttributes } from 'svelte/elements';
 
@@ -16,27 +16,36 @@ export type ToastTypes =
 export type PromiseT<Data = unknown> = Promise<Data> | (() => Promise<Data>);
 
 export type PromiseData<ToastData = unknown> = ExternalToast & {
-	loading?: string | Component;
-	// TODO: We need a way to differentiate between a callback and a component
-	// This is not possible with Svelte 5 atm, i've asked them to add a `isComponent` function
-	// or similar, so for now we remove the `Component` type from the union
-	// success?: string | Component | ((data: ToastData) => Component | string);
+	/**
+	 * The loading message or a function that returns the message or
+	 * a custom toast component.
+	 */
+	loading?: string | (() => Component | string);
+	/**
+	 * The success message or a function that returns the message or
+	 * a custom toast component.
+	 */
 	success?: string | ((data: ToastData) => Component | string);
-
-	// error?: string | Component | ((error: unknown) => Component | string);
+	/**
+	 * The error message or a function that returns the message or
+	 * a custom toast component.
+	 */
 	error?: string | ((error: unknown) => Component | string);
+	/**
+	 * A function that is called when the promise is finally resolved or rejected.
+	 */
 	finally?: () => void | Promise<void>;
 };
 
 export type ToastT<T extends Component = Component> = {
 	id: number | string;
-	title?: string | T;
+	title?: string | Component;
 	type: ToastTypes;
-	icon?: T;
-	component?: T;
-	componentProps?: Parameters<T>[1];
+	icon?: Component;
+	component?: Component;
+	componentProps?: ComponentProps<T>;
 	invert?: boolean;
-	description?: string | T;
+	description?: string | Component;
 	cancelButtonStyle?: string;
 	actionButtonStyle?: string;
 	duration?: number;
@@ -79,12 +88,6 @@ export type HeightT = {
 	height: number;
 	toastId: number | string;
 };
-
-export enum SwipeStateTypes {
-	SwipedOut = 'SwipedOut',
-	SwipedBack = 'SwipedBack',
-	NotSwiped = 'NotSwiped'
-}
 
 export type Theme = 'light' | 'dark';
 

--- a/src/routes/styles.css
+++ b/src/routes/styles.css
@@ -14,10 +14,12 @@
 	--gray12: hsl(0, 0%, 9%);
 	--hover: rgb(40, 40, 40);
 	--border-radius: 6px;
-	--font-sans: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto,
+	--font-sans:
+		ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto,
 		Helvetica Neue, Arial, Noto Sans, sans-serif, Apple Color Emoji, Segoe UI Emoji,
 		Segoe UI Symbol, Noto Color Emoji;
-	--font-mono: 'SF Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono,
+	--font-mono:
+		'SF Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono,
 		Courier New, monospace;
 }
 


### PR DESCRIPTION
Fixes type inference for the component props when passing a component to one of the `toast.X` functions.

Makes the various promise methods consistent.

Willl also working on bringing it up to parity with the original in terms of additions