### PR TITLE
fix: Move runed package to dependencies

### DIFF
--- a/.changeset/slimy-eggs-wonder.md
+++ b/.changeset/slimy-eggs-wonder.md
@@ -1,0 +1,5 @@
+---
+"svelte-sonner": patch
+---
+
+Fixes an issue where `runed` package can't be resolved due to it being in the `devDependencies` section instead of `dependencies`.

--- a/package.json
+++ b/package.json
@@ -43,6 +43,9 @@
 	"peerDependencies": {
 		"svelte": "^5.0.0"
 	},
+	"dependencies": {
+	  "runed": "^0.26.0"
+	},
 	"devDependencies": {
 		"@changesets/cli": "^2.27.1",
 		"@playwright/test": "^1.38.0",
@@ -71,7 +74,6 @@
 		"prettier": "^3.5.3",
 		"prettier-plugin-svelte": "^3.3.3",
 		"publint": "^0.2.2",
-		"runed": "^0.26.0",
 		"svelte": "^5.28.2",
 		"svelte-check": "^4.1.7",
 		"svelte-preprocess": "^6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      runed:
+        specifier: ^0.26.0
+        version: 0.26.0(svelte@5.28.2)
     devDependencies:
       '@changesets/cli':
         specifier: ^2.27.1
@@ -89,9 +93,6 @@ importers:
       publint:
         specifier: ^0.2.2
         version: 0.2.2
-      runed:
-        specifier: ^0.26.0
-        version: 0.26.0(svelte@5.28.2)
       svelte:
         specifier: ^5.28.2
         version: 5.28.2


### PR DESCRIPTION
Not sure if it was on purpose, but we need to move the `runed` package to dependencies since we use it in the library itself

Fixes https://github.com/wobsoriano/svelte-sonner/issues/146