### PR TITLE
Untrack state updates in toast creation

### DIFF
--- a/.changeset/beige-meals-own.md
+++ b/.changeset/beige-meals-own.md
@@ -1,0 +1,5 @@
+---
+"svelte-sonner": patch
+---
+
+untrack state dependencies in toast create and dismiss calls

--- a/src/lib/toast-state.svelte.ts
+++ b/src/lib/toast-state.svelte.ts
@@ -66,6 +66,10 @@ class ToastState {
 		const dismissable = data.dismissable === undefined ? true : data.dismissable;
 		const type = data.type === undefined ? 'default' : data.type;
 
+		// Avoid tracking access to state, namely `toasts`, so that
+		// toasts can be easily created in a $effect without
+		// special handling by users.
+		// See https://github.com/wobsoriano/svelte-sonner/issues/153
 		untrack(() => {
 			const alreadyExists = this.toasts.find((toast) => toast.id === id);
 

--- a/src/lib/toast-state.svelte.ts
+++ b/src/lib/toast-state.svelte.ts
@@ -9,6 +9,7 @@ import type {
 	ToastTypes
 } from './types.js';
 import { sonnerContext } from './internal/ctx.js';
+import { untrack } from 'svelte';
 
 let toastsCounter = 0;
 
@@ -65,13 +66,15 @@ class ToastState {
 		const dismissable = data.dismissable === undefined ? true : data.dismissable;
 		const type = data.type === undefined ? 'default' : data.type;
 
-		const alreadyExists = this.toasts.find((toast) => toast.id === id);
+		untrack(() => {
+			const alreadyExists = this.toasts.find((toast) => toast.id === id);
 
-		if (alreadyExists) {
-			this.updateToast({ id, data, type, message, dismissable });
-		} else {
-			this.addToast({ ...rest, id, title: message, dismissable, type });
-		}
+			if (alreadyExists) {
+				this.updateToast({ id, data, type, message, dismissable });
+			} else {
+				this.addToast({ ...rest, id, title: message, dismissable, type });
+			}
+		});
 
 		return id;
 	};

--- a/src/lib/toast-state.svelte.ts
+++ b/src/lib/toast-state.svelte.ts
@@ -84,16 +84,22 @@ class ToastState {
 	};
 
 	dismiss = (id?: number | string): string | number | undefined => {
-		if (id === undefined) {
-			// we're dismissing all the toasts
-			this.toasts = this.toasts.map((toast) => ({ ...toast, dismiss: true }));
-			return;
-		}
-		// we're dismissing a specific toast
-		const toastIdx = this.toasts.findIndex((toast) => toast.id === id);
-		if (this.toasts[toastIdx]) {
-			this.toasts[toastIdx] = { ...this.toasts[toastIdx], dismiss: true };
-		}
+		// Avoid tracking access to state, namely `toasts`, so that
+		// toasts can be easily dismissed in a $effect without
+		// special handling by users.
+		// See https://github.com/wobsoriano/svelte-sonner/issues/153
+		untrack(() => {
+			if (id === undefined) {
+				// we're dismissing all the toasts
+				this.toasts = this.toasts.map((toast) => ({ ...toast, dismiss: true }));
+				return;
+			}
+			// we're dismissing a specific toast
+			const toastIdx = this.toasts.findIndex((toast) => toast.id === id);
+			if (this.toasts[toastIdx]) {
+				this.toasts[toastIdx] = { ...this.toasts[toastIdx], dismiss: true };
+			}
+		});
 		return id;
 	};
 


### PR DESCRIPTION
This PR performs much of toast creation and dismisal inside an `untrack` call to make it easy for users to create toasts inside a $effect. Without this, the effect would trigger repeatedly as the `toasts` state is read and modified, becoming a dependency of the $effect itself.

I'm not entirely sure whether this makes sense or if there are unexpected consequences. I can't imagine why a user of this library would want svelte-sonner's internal state to become a dependency of their $effect 

See https://github.com/wobsoriano/svelte-sonner/issues/153