### PR TITLE
Avoid triggering nested updates in $effects

### DIFF
--- a/.changeset/cuddly-poems-melt.md
+++ b/.changeset/cuddly-poems-melt.md
@@ -1,0 +1,5 @@
+---
+"svelte-sonner": patch
+---
+
+Avoid triggering nested $effect updates on dismissal

--- a/src/lib/Toast.svelte
+++ b/src/lib/Toast.svelte
@@ -186,7 +186,12 @@
 
 		initialHeight = finalHeight;
 
-		toastState.setHeight({ toastId: toast.id, height: finalHeight });
+		// setHeight reads heights and toasts state. Untrack the call
+		// to avoid triggering this effect when those are modified. e.g. toasts
+		// added and removed.
+		untrack(() => {
+			toastState.setHeight({ toastId: toast.id, height: finalHeight });
+		});
 	});
 
 	function deleteToast() {
@@ -265,7 +270,12 @@
 
 	$effect(() => {
 		if (toast.delete) {
-			deleteToast();
+			// deleteToast reads and writes the heights and toasts state.
+			// Untrack the call to avoid triggering nested updates.
+			// See https://github.com/wobsoriano/svelte-sonner/issues/151
+			untrack(() => {
+				deleteToast();
+			});
 		}
 	});
 


### PR DESCRIPTION
$effect functions that read and write a state variable trigger nested updates: https://svelte.dev/docs/svelte/runtime-errors#Client-errors-effect_update_depth_exceeded. It's easy, if error prone, to avoid this by apply `untrack` carefully.

This PR applies untrack in two $effects. One that triggers when a toast's `delete` state is set to true, and the other that set's a toasts height when the title or description change.

Closes https://github.com/wobsoriano/svelte-sonner/issues/151