### PR TITLE
feat: add expandedGap prop for toast spacing when expanded

### DIFF
--- a/src/lib/Toast.svelte
+++ b/src/lib/Toast.svelte
@@ -2,8 +2,9 @@
 	// Default lifetime of a toasts (in ms)
 	const TOAST_LIFETIME = 4000;
 
-	// Default gap between toasts
-	const GAP = 14;
+
+	// Default gap between expanded toasts
+	const EXPANDED_GAP = 14;
 
 	// Threshold to dismiss a toast
 	const SWIPE_THRESHOLD = 45;
@@ -96,6 +97,7 @@
 		defaultRichColors = false,
 		swipeDirections: swipeDirectionsProp,
 		closeButtonAriaLabel,
+		expandedGap = EXPANDED_GAP,
 		...restProps
 	}: ToastProps = $props();
 
@@ -150,7 +152,7 @@
 	let closeTimerStartTime = $state(0);
 	let lastCloseTimerStartTime = $state(0);
 
-	const offset = $derived(Math.round(heightIndex * GAP + toastsHeightBefore));
+	const offset = $derived(Math.round(heightIndex * expandedGap + toastsHeightBefore));
 
 	$effect(() => {
 		toastTitle;

--- a/src/lib/Toaster.svelte
+++ b/src/lib/Toaster.svelte
@@ -14,8 +14,11 @@
 	// Default toast width
 	const TOAST_WIDTH = 356;
 
-	// Default gap between toasts
+	// Default gap between stacked toasts
 	const GAP = 14;
+
+	// Default gap between expanded toasts
+	const EXPANDED_GAP = 14;
 
 	const DARK = 'dark';
 	const LIGHT = 'light';
@@ -124,6 +127,7 @@
 		toastOptions = {},
 		dir = 'auto',
 		gap = GAP,
+		expandedGap = EXPANDED_GAP,
 		loadingIcon: loadingIconProp,
 		successIcon: successIconProp,
 		errorIcon: errorIconProp,
@@ -435,6 +439,7 @@
 							closeButtonAriaLabel}
 						expandByDefault={expand}
 						{expanded}
+						{expandedGap}
 						loadingIcon={loadingIconProp}
 					>
 						{#snippet successIcon()}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -217,11 +217,18 @@ export type ToasterProps = {
 	duration?: number;
 
 	/**
-	 * Gap between toasts when expanded, in pixels.
+	 * Gap between toasts when stacked, in pixels.
 	 *
-	 * @default '14px'
+	 * @default 14
 	 */
 	gap?: number;
+
+	/**
+	 * Gap between toasts when expanded, in pixels.
+	 *
+	 * @default 14
+	 */
+	expandedGap?: number;
 
 	/**
 	 * Amount of visible toasts
@@ -384,5 +391,6 @@ export type ToastProps = {
 	unstyled: boolean;
 	closeButtonAriaLabel: string;
 	defaultRichColors: boolean;
+	expandedGap?: number;
 } & HTMLAttributes<HTMLLIElement> &
 	ToastIcons;


### PR DESCRIPTION
   ## Description
   
   Adds a new `expandedGap` prop to allow independent configuration of the gap between toasts when they are expanded, separate from the `gap` prop which controls stacked toast spacing.
 