### PR TITLE
Generate provenance statement on release to increase security

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
         permissions:
             contents: write # to create release (changesets/action)
             pull-requests: write # to create pull request (changesets/action)
+            id-token: write
         name: Release
         runs-on: ubuntu-latest
         steps:
@@ -38,3 +39,4 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+                  NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
Following recent hacks on npm packages, it would be greatly appreciated if you could increase the trust level of the npm packages.

I added generation of provenance statements as outlined in this guide from npm: https://docs.npmjs.com/generating-provenance-statements