### PR TITLE
fix: toaster should take children props

### DIFF
--- a/src/lib/Toaster.svelte
+++ b/src/lib/Toaster.svelte
@@ -110,6 +110,7 @@
 	}
 
 	let {
+		children,
 		invert = false,
 		position = 'bottom-right',
 		hotkey = ['altKey', 'KeyT'],
@@ -482,6 +483,8 @@
 		{/each}
 	{/if}
 </section>
+
+{@render children?.()}
 
 <style global lang="postcss">
 	html[dir='ltr'],

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -165,6 +165,11 @@ type ToastIcons = {
 
 export type ToasterProps = {
 	/**
+	 * Children. Guaranteed to have a toaster context here.
+	 */
+	children?: Snippet<[]>;
+
+	/**
 	 * Dark toasts in light mode and vice versa.
 	 *
 	 * @default false


### PR DESCRIPTION
# Design modification

`Toaster` now takes `children` props, like any other Provider-like components in Svelte.
Within the children's scope, it is guaranteed that `Toaster` is mounted and toaster context is initialized.

# What does it fix?

Fixes #181, and possibly #120.