### PR TITLE
Add ability to disable swipe entirely

### DIFF
--- a/src/components/SwipeDirections.svelte
+++ b/src/components/SwipeDirections.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+	import { toast } from '$lib/index.js';
+	import type {
+		Position as PositionType,
+		SwipeDirection
+	} from '$lib/types.js';
+	import CodeBlock from './CodeBlock.svelte';
+
+	type SwipePreset = SwipeDirection[] | undefined;
+
+	let {
+		position,
+		swipeDirections,
+		setSwipeDirections
+	}: {
+		position: PositionType;
+		swipeDirections: SwipePreset;
+		setSwipeDirections: (swipeDirections: SwipePreset) => void;
+	} = $props();
+
+	const presets: Array<{ label: string; directions: SwipePreset }> = [
+		{ label: 'Position default', directions: undefined },
+		{ label: 'Horizontal', directions: ['left', 'right'] },
+		{ label: 'Vertical', directions: ['top', 'bottom'] },
+		{ label: 'Disabled', directions: [] }
+	];
+
+	function areDirectionsEqual(a: SwipePreset, b: SwipePreset) {
+		if (a === undefined || b === undefined) return a === b;
+		if (a.length !== b.length) return false;
+		return a.every((direction, index) => direction === b[index]);
+	}
+
+	const snippet = $derived.by(() => {
+		if (swipeDirections === undefined) {
+			return `<Toaster position="${position}" />`;
+		}
+
+		if (swipeDirections.length === 0) {
+			return `<Toaster position="${position}" swipeDirections={[]} />`;
+		}
+
+		return `<Toaster position="${position}" swipeDirections={['${swipeDirections.join("', '")}']} />`;
+	});
+</script>
+
+<div>
+	<h2>Swipe Directions</h2>
+	<p>
+		Defaults follow <code>position</code>; override with
+		<code>swipeDirections</code> or disable with an empty array.
+	</p>
+	<div class="buttons">
+		{#each presets as preset (preset.label)}
+			<button
+				class="button"
+				data-active={areDirectionsEqual(swipeDirections, preset.directions)}
+				onclick={() => {
+					setSwipeDirections(preset.directions);
+					toast('Event has been created', {
+						description: 'Monday, January 3rd at 6:00pm'
+					});
+				}}
+			>
+				{preset.label}
+			</button>
+		{/each}
+	</div>
+	<CodeBlock code={snippet} />
+</div>

--- a/src/lib/Toast.svelte
+++ b/src/lib/Toast.svelte
@@ -141,6 +141,12 @@
 	const isDocumentHidden = useDocumentHidden();
 	const invert = $derived(toast.invert || invertFromToaster);
 	const disabled = $derived(toastType === 'loading');
+	const swipeDirections = $derived(
+		swipeDirectionsProp ?? getDefaultSwipeDirections(position)
+	);
+	const swipeEnabled = $derived(
+		dismissable && !disabled && swipeDirections.length > 0
+	);
 
 	const classes = $derived({ ...defaultClasses, ...classesProp });
 
@@ -273,20 +279,20 @@
 	});
 
 	const handlePointerDown: PointerEventHandler<HTMLLIElement> = (event) => {
-		if (disabled) return;
+		if (!swipeEnabled) return;
 
 		offsetBeforeRemove = offset;
 		const target = event.target as HTMLElement;
 
 		// ensure we maintain correct pointer capture even when going outside of the toast (e.g. when swiping)
-		target.setPointerCapture(event.pointerId);
+		target.setPointerCapture?.(event.pointerId);
 		if (target.tagName === 'BUTTON') return;
 		swiping = true;
 		pointerStart = { x: event.clientX, y: event.clientY };
 	};
 
 	const handlePointerUp: PointerEventHandler<HTMLLIElement> = () => {
-		if (swipeOut || !dismissable) return;
+		if (swipeOut || !swipeEnabled) return;
 
 		pointerStart = null;
 		const swipeAmountX = Number(
@@ -330,7 +336,7 @@
 	};
 
 	const handlePointerMove: PointerEventHandler<HTMLLIElement> = (event) => {
-		if (!pointerStart || !dismissable) return;
+		if (!pointerStart || !swipeEnabled) return;
 
 		const isHighlighted =
 			(window.getSelection()?.toString().length ?? -1) > 0;
@@ -338,9 +344,6 @@
 
 		const yDelta = event.clientY - pointerStart.y;
 		const xDelta = event.clientX - pointerStart.x;
-
-		const swipeDirections =
-			swipeDirectionsProp ?? getDefaultSwipeDirections(position);
 
 		// Determine swipe direction if not already locked
 		if (!swipeDirection && (Math.abs(xDelta) > 1 || Math.abs(yDelta) > 1)) {
@@ -471,10 +474,10 @@
 	style:--offset={`${removed ? offsetBeforeRemove : offset}px`}
 	style:--initial-height={expandByDefault ? 'auto' : `${initialHeight}px`}
 	style={`${restProps.style} ${toast.style}`}
-	onpointermove={handlePointerMove}
-	onpointerup={handlePointerUp}
-	onpointerdown={handlePointerDown}
-	ondragend={handleDragEnd}
+	onpointermove={swipeEnabled ? handlePointerMove : undefined}
+	onpointerup={swipeEnabled ? handlePointerUp : undefined}
+	onpointerdown={swipeEnabled ? handlePointerDown : undefined}
+	ondragend={swipeEnabled ? handleDragEnd : undefined}
 >
 	{#if closeButton && !toast.component && toastType !== 'loading' && closeIcon !== null}
 		<button

--- a/src/lib/Toaster.svelte
+++ b/src/lib/Toaster.svelte
@@ -121,6 +121,7 @@
 		richColors = false,
 		duration = TOAST_LIFETIME,
 		visibleToasts = VISIBLE_TOASTS_AMOUNT,
+		swipeDirections,
 		toastOptions = {},
 		dir = 'auto',
 		gap = GAP,
@@ -421,6 +422,7 @@
 						descriptionClass={toastOptions?.descriptionClass || ''}
 						{invert}
 						{visibleToasts}
+						{swipeDirections}
 						{closeButton}
 						{interacting}
 						{position}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,18 +1,23 @@
 <script lang="ts">
 	import { Toaster } from '$lib/index.js';
-	import type { Position as PositionType } from '$lib/types.js';
+	import type {
+		Position as PositionType,
+		SwipeDirection
+	} from '$lib/types.js';
 	import Expand from '../components/Expand.svelte';
 	import Footer from '../components/Footer.svelte';
 	import Hero from '../components/Hero.svelte';
 	import Installation from '../components/Installation.svelte';
 	import Other from '../components/Other.svelte';
 	import Position from '../components/Position.svelte';
+	import SwipeDirections from '../components/SwipeDirections.svelte';
 	import Types from '../components/Types.svelte';
 	import Usage from '../components/Usage.svelte';
 	import { richColorsContext } from '$lib/internal/ctx.js';
 
 	let expand = $state(false);
 	let position = $state<PositionType>('bottom-right');
+	let swipeDirections = $state<SwipeDirection[] | undefined>(undefined);
 
 	let richColors = $state(false);
 	let closeButton = $state(false);
@@ -56,7 +61,7 @@
 	/>
 </svelte:head>
 
-<Toaster {expand} {position} {richColors} {closeButton} />
+<Toaster {expand} {position} {swipeDirections} {richColors} {closeButton} />
 <main class="container">
 	<Hero />
 	<div class="content">
@@ -64,6 +69,11 @@
 		<Usage />
 		<Types />
 		<Position {position} setPosition={(pos) => (position = pos)} />
+		<SwipeDirections
+			{position}
+			{swipeDirections}
+			setSwipeDirections={(value) => (swipeDirections = value)}
+		/>
 		<Expand {expand} setExpand={(exp) => (expand = exp)} />
 		<Other
 			bind:closeButton

--- a/src/tests/ToastTest.svelte
+++ b/src/tests/ToastTest.svelte
@@ -1,12 +1,16 @@
 <script lang="ts">
+	import type { ToasterProps } from '$lib/types.js';
 	import { Toaster, toast } from '$lib/index.js';
-	const { cb }: { cb: (t: typeof toast) => void } = $props();
+	const {
+		cb,
+		toasterProps = {}
+	}: { cb: (t: typeof toast) => void; toasterProps?: ToasterProps } = $props();
 
 	function onClick() {
 		cb(toast);
 	}
 </script>
 
-<Toaster />
+<Toaster {...toasterProps} />
 
 <button data-testid="trigger" onclick={onClick}>Trigger</button>

--- a/src/tests/toast.spec.ts
+++ b/src/tests/toast.spec.ts
@@ -1,11 +1,15 @@
 import { describe, it } from 'vitest';
 import ToastTest from './ToastTest.svelte';
-import { render, waitFor } from '@testing-library/svelte';
+import { fireEvent, render, waitFor } from '@testing-library/svelte';
 import { userEvent } from '@testing-library/user-event';
 import { toast, toastState } from '$lib/toast-state.svelte.js';
+import type { ToasterProps } from '$lib/types.js';
 import { sleep } from './utils.js';
 
-function setup(props: { cb: (t: typeof toast) => void }) {
+function setup(props: {
+	cb: (t: typeof toast) => void;
+	toasterProps?: ToasterProps;
+}) {
 	const user = userEvent.setup();
 	const returned = render(ToastTest, { props });
 	const trigger = returned.getByTestId('trigger');
@@ -125,5 +129,38 @@ describe('Toast', () => {
 		expect(getByText('Finished loading!')).toBeVisible();
 		await sleep(2200);
 		expect(getByText('Finished loading!')).toBeVisible();
+	});
+
+	it('should disable swiping when swipeDirections is empty', async () => {
+		const { user, trigger, container, getByText } = setup({
+			cb: (toast) => toast('Hello world', { duration: 5000 }),
+			toasterProps: { swipeDirections: [] }
+		});
+
+		await user.click(trigger);
+		const toastEl = container.querySelector<HTMLElement>('[data-sonner-toast]');
+		expect(toastEl).not.toBeNull();
+		if (!toastEl) return;
+
+		await fireEvent.pointerDown(toastEl, {
+			clientX: 100,
+			clientY: 100,
+			pointerId: 1
+		});
+		await fireEvent.pointerMove(toastEl, {
+			clientX: 250,
+			clientY: 100,
+			pointerId: 1
+		});
+		await fireEvent.pointerUp(toastEl, {
+			clientX: 250,
+			clientY: 100,
+			pointerId: 1
+		});
+
+		expect(getByText('Hello world')).toBeVisible();
+		expect(toastEl.dataset.swiped).toBe('false');
+		expect(toastEl.style.getPropertyValue('--swipe-amount-x')).toBe('');
+		expect(toastEl.style.getPropertyValue('--swipe-amount-y')).toBe('');
 	});
 });


### PR DESCRIPTION
This PR is mainly for me, I have a weird issue where the swiping gesture would get stuck, but I couldn't find a reliable reproduction so instead I ended up with this.

Setting `swipeDirections` to an empty array right now still activates the swipe logic, but just doesn't dismiss the toast which means that there is no way to disable swiping right now. This PR changes that and an empty array now makes it so that it disable swiping.

I'm open to change this to a extra prop, but I wanted to keep the changes minimal.

(Also `Toaster` never passed `swipeDirections` to `Toast` this PR fixes that as well)