### PR TITLE
feat: add `pauseWhenPageIsHidden` and rename `dismissable` -> `dismissible`

### DIFF
--- a/.changeset/dull-yaks-rhyme.md
+++ b/.changeset/dull-yaks-rhyme.md
@@ -2,4 +2,4 @@
 'svelte-sonner': minor
 ---
 
-Add pauseWhenPageIsHidden prop, important option for aria-live, content class in ToastClasses, and rename dismissable to dismissible (deprecated alias kept for backwards compatibility)
+Add `pauseWhenPageIsHidden` prop and rename dismissable to dismissible (deprecated alias kept for backwards compatibility)

--- a/.changeset/dull-yaks-rhyme.md
+++ b/.changeset/dull-yaks-rhyme.md
@@ -1,0 +1,5 @@
+---
+'svelte-sonner': minor
+---
+
+Add pauseWhenPageIsHidden prop, important option for aria-live, content class in ToastClasses, and rename dismissable to dismissible (deprecated alias kept for backwards compatibility)

--- a/src/lib/Toast.svelte
+++ b/src/lib/Toast.svelte
@@ -96,6 +96,7 @@
 		defaultRichColors = false,
 		swipeDirections: swipeDirectionsProp,
 		closeButtonAriaLabel,
+		pauseWhenPageIsHidden,
 		...restProps
 	}: ToastProps = $props();
 
@@ -118,7 +119,11 @@
 	const isFront = $derived(index === 0);
 	const isVisible = $derived(index + 1 <= visibleToasts);
 	const toastType = $derived(toast.type);
-	const dismissable = $derived(toast.dismissable !== false);
+	const dismissible = $derived(
+		toast.dismissible !== undefined
+			? toast.dismissible !== false
+			: toast.dismissable !== false
+	);
 	const toastClass = $derived(toast.class || '');
 	const toastDescriptionClass = $derived(toast.descriptionClass || '');
 	// height index is used to calculate the offset as it gets updated before the toast array, which means we can calculate the new layout faster.
@@ -240,7 +245,7 @@
 
 	$effect(() => {
 		if (!isPromiseLoadingOrInfiniteDuration) {
-			if (expanded || interacting || isDocumentHidden.current) {
+			if (expanded || interacting || (pauseWhenPageIsHidden && isDocumentHidden.current)) {
 				pauseTimer();
 			} else {
 				startTimer();
@@ -286,7 +291,7 @@
 	};
 
 	const handlePointerUp: PointerEventHandler<HTMLLIElement> = () => {
-		if (swipeOut || !dismissable) return;
+		if (swipeOut || !dismissible) return;
 
 		pointerStart = null;
 		const swipeAmountX = Number(
@@ -330,7 +335,7 @@
 	};
 
 	const handlePointerMove: PointerEventHandler<HTMLLIElement> = (event) => {
-		if (!pointerStart || !dismissable) return;
+		if (!pointerStart || !dismissible) return;
 
 		const isHighlighted =
 			(window.getSelection()?.toString().length ?? -1) > 0;
@@ -446,6 +451,8 @@
 		classes?.[toastType],
 		toast?.classes?.[toastType]
 	)}
+	aria-live={toast.important ? 'assertive' : 'polite'}
+	aria-atomic="true"
 	data-sonner-toast=""
 	data-rich-colors={toast.richColors ?? defaultRichColors}
 	data-styled={!(toast.component || toast.unstyled || unstyled)}
@@ -459,7 +466,7 @@
 	data-index={index}
 	data-front={isFront}
 	data-swiping={swiping}
-	data-dismissable={dismissable}
+	data-dismissible={dismissible}
 	data-type={toastType}
 	data-invert={invert}
 	data-swipe-out={swipeOut}
@@ -482,7 +489,7 @@
 			data-disabled={disabled}
 			data-close-button
 			onclick={() => {
-				if (disabled || !dismissable) return;
+				if (disabled || !dismissible) return;
 				deleteToast();
 				toast.onDismiss?.(toast);
 			}}
@@ -520,7 +527,7 @@
 				{/if}
 			</div>
 		{/if}
-		<div data-content="">
+		<div data-content="" class={cn(classes?.content, toast?.classes?.content)}>
 			<div
 				data-title=""
 				class={cn(classes?.title, toast?.classes?.title)}
@@ -567,7 +574,7 @@
 					)}
 					onclick={(event) => {
 						if (!isAction(toast.cancel)) return;
-						if (!dismissable) return;
+						if (!dismissible) return;
 						toast.cancel?.onClick?.(event);
 						deleteToast();
 					}}

--- a/src/lib/Toaster.svelte
+++ b/src/lib/Toaster.svelte
@@ -124,6 +124,7 @@
 		toastOptions = {},
 		dir = 'auto',
 		gap = GAP,
+		pauseWhenPageIsHidden = false,
 		loadingIcon: loadingIconProp,
 		successIcon: successIconProp,
 		errorIcon: errorIconProp,
@@ -308,7 +309,7 @@
 		onfocus?.(event);
 		const isNotDismissable =
 			event.target instanceof HTMLElement &&
-			event.target.dataset.dismissable === 'false';
+			event.target.dataset.dismissible === 'false';
 
 		if (isNotDismissable) return;
 
@@ -324,7 +325,7 @@
 		onpointerdown?.(event);
 		const isNotDismissable =
 			event.target instanceof HTMLElement &&
-			event.target.dataset.dismissable === 'false';
+			event.target.dataset.dismissible === 'false';
 
 		if (isNotDismissable) return;
 		interacting = true;
@@ -436,6 +437,7 @@
 							closeButtonAriaLabel}
 						expandByDefault={expand}
 						{expanded}
+						{pauseWhenPageIsHidden}
 						loadingIcon={loadingIconProp}
 					>
 						{#snippet successIcon()}

--- a/src/lib/toast-state.svelte.ts
+++ b/src/lib/toast-state.svelte.ts
@@ -18,7 +18,7 @@ type UpdateToastProps = {
 	data: Partial<ToastT>;
 	type: ToastTypes;
 	message: string | AnyComponent | undefined;
-	dismissable: boolean;
+	dismissible: boolean;
 };
 
 class ToastState {
@@ -63,16 +63,22 @@ class ToastState {
 				? data.id
 				: toastsCounter++;
 
-		const dismissable = data.dismissable === undefined ? true : data.dismissable;
+		// Support deprecated `dismissable` as a fallback for backwards compatibility
+		const dismissible =
+			data.dismissible !== undefined
+				? data.dismissible
+				: data.dismissable !== undefined
+					? data.dismissable
+					: true;
 		const type = data.type === undefined ? 'default' : data.type;
 
 		untrack(() => {
 			const alreadyExists = this.toasts.find((toast) => toast.id === id);
 
 			if (alreadyExists) {
-				this.updateToast({ id, data, type, message, dismissable });
+				this.updateToast({ id, data, type, message, dismissible });
 			} else {
-				this.addToast({ ...rest, id, title: message, dismissable, type });
+				this.addToast({ ...rest, id, title: message, dismissible, type });
 			}
 		});
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -62,7 +62,12 @@ export type ToastT<T extends AnyComponent = AnyComponent> = {
 	richColors?: boolean;
 	invert?: boolean;
 	closeButton?: boolean;
+	dismissible?: boolean;
+	/**
+	 * @deprecated Use `dismissible` instead.
+	 */
 	dismissable?: boolean;
+	important?: boolean;
 	description?: string | AnyComponent;
 	duration?: number;
 	delete?: boolean;
@@ -259,6 +264,14 @@ export type ToasterProps = {
 	mobileOffset?: Offset;
 
 	/**
+	 * Pause the toast timer when the page is hidden, e.g. when the user switches
+	 * tabs. Toasts will not expire while the page is hidden.
+	 *
+	 * @default false
+	 */
+	pauseWhenPageIsHidden?: boolean;
+
+	/**
 	 * Directionality of toast's text
 	 *
 	 * @default 'auto'
@@ -358,6 +371,7 @@ export type ToastClasses = {
 	cancelButton?: string;
 	actionButton?: string;
 	icon?: string;
+	content?: string;
 } & ToastTypeClasses;
 
 type ToastTypeClasses = Partial<Record<ToastTypes, string>>;
@@ -384,5 +398,6 @@ export type ToastProps = {
 	unstyled: boolean;
 	closeButtonAriaLabel: string;
 	defaultRichColors: boolean;
+	pauseWhenPageIsHidden: boolean;
 } & HTMLAttributes<HTMLLIElement> &
 	ToastIcons;


### PR DESCRIPTION
## Summary

- Add `pauseWhenPageIsHidden` prop to Toaster (default false); previously timers always paused on hidden tabs
- Add `important` option on toasts to set aria-live="assertive" for urgent screen-reader announcements
- Add `content` class to ToastClasses targeting the data-content wrapper div
- Rename `dismissable` -> `dismissible` (correct spelling); deprecated alias kept for backwards compatibility