### PR TITLE
Added toasterId for multiple Toaster instances

### DIFF
--- a/.changeset/tall-moons-flow.md
+++ b/.changeset/tall-moons-flow.md
@@ -1,0 +1,5 @@
+---
+'svelte-sonner': minor
+---
+
+Add support for targeting specific `<Toaster />` instances via `<Toaster id="..." />` and `toast(..., { toasterId })`

--- a/README.md
+++ b/README.md
@@ -182,6 +182,22 @@ You can change the position through the `position` prop on the `<Toaster />` com
 <Toaster position="top-center" />
 ```
 
+### Multiple Toasters
+
+You can render multiple toasters if you need this clear separation. This then enables you to point a toast to a specific toaster.
+
+```svelte
+<Toaster id="global" position="top-right" />
+<Toaster id="canvas" position="bottom-left" />
+
+<button onclick={() => toast('Global toast', { toasterId: 'global' })}>
+	Show in Global Toaster
+</button>
+<button onclick={() => toast('Canvas toast', { toasterId: 'canvas' })}>
+	Show in Canvas Toaster
+</button>
+```
+
 ### Expanded
 
 Toasts can also be expanded by default through the `expand` prop. You can also change the amount of visible toasts which is 3 by default.

--- a/src/lib/Toaster.svelte
+++ b/src/lib/Toaster.svelte
@@ -77,8 +77,7 @@
 	import { onMount, untrack } from 'svelte';
 	import { SonnerState, toastState } from './toast-state.svelte';
 	import Toast from './Toast.svelte';
-	import type { ToasterProps } from './types.js';
-	import type { Position } from './types.js';
+	import type { ToastT, ToasterProps, Position } from './types.js';
 	import type {
 		DragEventHandler,
 		FocusEventHandler,
@@ -109,7 +108,15 @@
 		return LIGHT;
 	}
 
+	function isToastForToaster(toast: ToastT, toasterId: ToastT['toasterId']) {
+		// Untargeted toasts render only in the default/global toaster that does not have an
+		// explicit id
+		if (toast.toasterId === undefined) return toasterId === undefined;
+		return toast.toasterId === toasterId;
+	}
+
 	let {
+		id: toasterId,
 		invert = false,
 		position = 'bottom-right',
 		hotkey = ['altKey', 'KeyT'],
@@ -145,6 +152,10 @@
 		...restProps
 	}: ToasterProps = $props();
 
+	const toasts = $derived(
+		toastState.toasts.filter((toast) => isToastForToaster(toast, toasterId))
+	);
+
 	function getDocumentDirection(): ToasterProps['dir'] {
 		if (dir !== 'auto') return dir;
 		if (typeof window === 'undefined') return 'ltr';
@@ -173,7 +184,7 @@
 			new Set(
 				[
 					position,
-					...toastState.toasts
+					...toasts
 						.filter((toast) => toast.position)
 						.map((toast) => toast.position)
 				].filter(Boolean)
@@ -193,7 +204,7 @@
 	);
 
 	$effect(() => {
-		if (toastState.toasts.length <= 1) {
+		if (toasts.length <= 1) {
 			expanded = false;
 		}
 	});
@@ -370,7 +381,7 @@
 	aria-relevant="additions text"
 	aria-atomic="false"
 >
-	{#if toastState.toasts.length > 0}
+	{#if toasts.length > 0}
 		{#each possiblePositions as position, index (position)}
 			{@const [y, x] = position.split('-')}
 			{@const offsetObject = getOffsetObject(offset, mobileOffset)}
@@ -413,7 +424,7 @@
 				onpointerup={handlePointerUp}
 				{...restProps}
 			>
-				{#each toastState.toasts.filter((toast) => (!toast.position && index === 0) || toast.position === position) as toast, index (toast.id)}
+				{#each toasts.filter((toast) => (!toast.position && index === 0) || toast.position === position) as toast, index (toast.id)}
 					<Toast
 						{index}
 						{toast}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -54,6 +54,7 @@ export function isAction(action: ToastAction | AnyComponent | undefined): action
 
 export type ToastT<T extends AnyComponent = AnyComponent> = {
 	id: number | string;
+	toasterId?: string;
 	title?: string | AnyComponent;
 	type: ToastTypes;
 	icon?: AnyComponent | null;
@@ -169,6 +170,14 @@ type ToastIcons = {
 };
 
 export type ToasterProps = {
+	/**
+	 * Unique ID for this toaster instance.
+	 *
+	 * Use together with `toast(..., { toasterId })` to target specific toasters when
+	 * multiple are rendered.
+	 */
+	id?: string;
+
 	/**
 	 * Dark toasts in light mode and vice versa.
 	 *

--- a/src/tests/MultipleToasterTest.svelte
+++ b/src/tests/MultipleToasterTest.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import { Toaster, toast } from '$lib/index.js';
+
+	function showGlobalToast() {
+		toast('Global Toaster Toast');
+	}
+
+	function showSecondaryToast() {
+		toast('Secondary Toaster Toast', { toasterId: 'secondary' });
+	}
+</script>
+
+<Toaster position="bottom-right" />
+<Toaster id="secondary" position="top-left" />
+
+<button data-testid="toast-global" onclick={showGlobalToast}>
+	Show in Global Toaster
+</button>
+<button data-testid="toast-secondary" onclick={showSecondaryToast}>
+	Show in Secondary Toaster
+</button>

--- a/src/tests/toaster.spec.ts
+++ b/src/tests/toaster.spec.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { render, waitFor, within } from '@testing-library/svelte';
+import { userEvent } from '@testing-library/user-event';
+import MultipleToasterTest from './MultipleToasterTest.svelte';
+import { toastState } from '$lib/toast-state.svelte.js';
+
+function setup() {
+	const user = userEvent.setup();
+	const returned = render(MultipleToasterTest);
+
+	return {
+		user,
+		...returned
+	};
+}
+
+function getToaster(
+	container: HTMLElement,
+	y: 'top' | 'bottom',
+	x: 'right' | 'left'
+): HTMLOListElement {
+	const toaster = container.querySelector<HTMLOListElement>(
+		`[data-sonner-toaster][data-y-position="${y}"][data-x-position="${x}"]`
+	);
+
+	if (!toaster) {
+		throw new Error(`Expected toaster at ${y}-${x} to be rendered`);
+	}
+
+	return toaster;
+}
+
+describe('Toaster id', () => {
+	beforeEach(() => {
+		toastState.reset();
+	});
+
+	it('toast with toasterId only appears in the correct Toaster', async () => {
+		const { user, getByTestId, container } = setup();
+
+		await user.click(getByTestId('toast-secondary'));
+		const secondaryToaster = getToaster(container, 'top', 'left');
+
+		await waitFor(() => {
+			expect(within(secondaryToaster).queryAllByText('Secondary Toaster Toast')).toHaveLength(
+				1
+			);
+		});
+
+		const globalToaster = container.querySelector<HTMLOListElement>(
+			'[data-sonner-toaster][data-x-position="right"][data-y-position="bottom"]'
+		);
+		expect(
+			globalToaster
+				? within(globalToaster).queryAllByText('Secondary Toaster Toast').length
+				: 0
+		).toBe(0);
+	});
+
+	it('toast without toasterId only appears in the global Toaster', async () => {
+		const { user, getByTestId, container } = setup();
+
+		await user.click(getByTestId('toast-global'));
+		const globalToaster = getToaster(container, 'bottom', 'right');
+		await waitFor(() => {
+			expect(within(globalToaster).queryAllByText('Global Toaster Toast')).toHaveLength(1);
+		});
+
+		const secondaryToaster = container.querySelector<HTMLOListElement>(
+			'[data-sonner-toaster][data-x-position="left"][data-y-position="top"]'
+		);
+		expect(
+			secondaryToaster
+				? within(secondaryToaster).queryAllByText('Global Toaster Toast').length
+				: 0
+		).toBe(0);
+	});
+});


### PR DESCRIPTION
https://github.com/wobsoriano/svelte-sonner/issues/180

## Summary
- added support for routing Toasts to specific Toaster instances via `toast(..., { toasterId })`
- added `id` support on `<Toaster />` to identify Toaster instances
- aligned untargeted Toast behavior with Sonner where Toasts without `toasterId` render only in the default/global Toaster (`<Toaster />` without `id`)
- documented multiple Toaster usage with the `global`/`canvas` example
- added coverage in `src/tests/toaster.spec.ts` and fixture `src/tests/MultipleToasterTest.svelte`

## API
- `ToastT` now includes optional `toasterId?: string`
- `ToasterProps` now includes optional `id?: string`

## Tests
- `pnpm test:unit src/tests/toaster.spec.ts`

## Changeset
- minor