### PR TITLE
fix: setHeight uses heights index not toast index — prevents TypeError on heights.findIndex

### DIFF
--- a/src/lib/toast-state.svelte.ts
+++ b/src/lib/toast-state.svelte.ts
@@ -228,7 +228,13 @@ class ToastState {
 	};
 
 	setHeight = (data: HeightT) => {
-		const heightIdx = this.heights.findIndex((h) => h.toastId === data.toastId);
+		// untrack the read so that callers inside $effect (e.g. Toast.svelte's
+		// height-measurement effect) don't subscribe to this.heights — which
+		// would re-trigger the effect when the subsequent push/assignment
+		// mutates the same array, causing effect_update_depth_exceeded.
+		const heightIdx = untrack(() =>
+			this.heights.findIndex((h) => h.toastId === data.toastId)
+		);
 		if (heightIdx === -1) {
 			this.heights.push(data);
 		} else {

--- a/src/lib/toast-state.svelte.ts
+++ b/src/lib/toast-state.svelte.ts
@@ -228,12 +228,12 @@ class ToastState {
 	};
 
 	setHeight = (data: HeightT) => {
-		const toastIdx = this.#findToastIdx(data.toastId);
-		if (toastIdx === null) {
+		const heightIdx = this.heights.findIndex((h) => h.toastId === data.toastId);
+		if (heightIdx === -1) {
 			this.heights.push(data);
-			return;
+		} else {
+			this.heights[heightIdx] = data;
 		}
-		this.heights[toastIdx] = data;
 	};
 
 	reset = () => {


### PR DESCRIPTION
Fixes #194

## Problem

`setHeight` looks up a toast's position in `this.toasts` and uses that
same integer as an index into `this.heights`. The two arrays are not
kept in sync:

- `addToast` **unshifts** into `toasts`; heights are **pushed** (appended)
- `remove` **splices** `toasts`; only `removeHeight` touches `heights`

So after any add or remove, `toastIdx` no longer corresponds to a valid
slot in `heights`. When `toastIdx >= heights.length`, the assignment
`this.heights[toastIdx] = data` creates a **sparse array with `undefined`
holes**.

`Toast.svelte` then does:

```ts
const heightIndex = $derived(
  toastState.heights.findIndex((height) => height.toastId === toast.id)
```

The `findIndex` callback receives an `undefined` element and crashes:

```
TypeError: Cannot read properties of undefined (reading 'toastId')
```

This is an unhandled error that tears down the component tree.

## Fix

Search `heights` by `toastId` — exactly as `removeHeight` already does —
instead of reusing a toast-array index:

```ts
// Before
setHeight = (data: HeightT) => {
  const toastIdx = this.#findToastIdx(data.toastId); // index in `toasts`
  if (toastIdx === null) {
    this.heights.push(data);
    return;
  }
  this.heights[toastIdx] = data; // ← wrong array, wrong index
};

// After
setHeight = (data: HeightT) => {
  const heightIdx = this.heights.findIndex((h) => h.toastId === data.toastId);
  if (heightIdx === -1) {
    this.heights.push(data);
  } else {
    this.heights[heightIdx] = data; // ← correct: index within heights
  }
};
```

This makes `setHeight` and `removeHeight` symmetric (both search by
`toastId`) and eliminates any possibility of sparse holes in `heights`.

## Production evidence

Observed on a production Svelte 5 app with `svelte-sonner@1.0.7` /
`1.1.0`. 10 occurrences across 5 distinct users within 24 hours.
Triggered consistently when multiple toasts are shown in quick succession.
Full stack trace and analysis in issue #194.