### PR TITLE
fix: dont restart auto-close timer on infinite-duration toast update

### DIFF
--- a/.changeset/poor-papayas-work.md
+++ b/.changeset/poor-papayas-work.md
@@ -1,0 +1,5 @@
+---
+'svelte-sonner': patch
+---
+
+Fix infinite-duration toasts being dismissed immediately when updated

--- a/src/lib/Toast.svelte
+++ b/src/lib/Toast.svelte
@@ -239,7 +239,9 @@
 			// new duration
 			clearTimeout(timeoutId);
 			remainingTime = duration;
-			startTimer();
+			if (!isPromiseLoadingOrInfiniteDuration) {
+				startTimer();
+			}
 		}
 	});
 


### PR DESCRIPTION
Closes #178

## Root cause

  The `$effect` triggered by `toast.updated` (`Toast.svelte:235`) unconditionally calls `startTimer()`:

  ```ts
  $effect(() => {
      if (toast.updated) {
          clearTimeout(timeoutId);
          remainingTime = duration;
          startTimer();
      }
  });
  ```

  `startTimer()` schedules `setTimeout(cb, remainingTime)`. When the original toast was created with `duration: Infinity` and the update doesn't override it,
  `remainingTime === Infinity`. Per the HTML spec, `setTimeout` clamps any delay > 2³¹−1 to `1ms` — so the toast auto-closes ~immediately instead of staying.

  The sibling effect at `Toast.svelte:247` already guards against this with `isPromiseLoadingOrInfiniteDuration`. The `toast.updated` effect just forgot the same
  guard.

  ## Fix

  Mirror the sibling effect's guard:

  ```diff
   $effect(() => {
       if (toast.updated) {
           clearTimeout(timeoutId);
           remainingTime = duration;
  -        startTimer();
  +        if (!isPromiseLoadingOrInfiniteDuration) {
  +            startTimer();
  +        }
       }
   });
  ```

  ## Behavior

  - Update without specifying `duration` → toast keeps its `Infinity` duration (stays until explicitly dismissed)
  - Update with explicit `duration` → uses the new duration

  This matches upstream sonner's behavior, fixed the same way in [emilkowalski/sonner#206](https://github.com/emilkowalski/sonner/pull/206) (merged 2023-10-26).

  ## Reproduction

  From the issue's StackBlitz:

  ```ts
  const id = toast.message('My awesome toast', { duration: Infinity });
  setTimeout(() => {
      toast.success('success!', { id }); // Before: dismissed immediately. After: stays.
  }, 1000);
  ```