### PR TITLE
fix: setHeight keys into heights by toastId to prevent sparse-array crash

### DIFF
--- a/.changeset/fix-setheight-sparse-array.md
+++ b/.changeset/fix-setheight-sparse-array.md
@@ -1,0 +1,21 @@
+---
+"svelte-sonner": patch
+---
+
+fix: prevent `Cannot read properties of undefined (reading 'toastId')` crash from `setHeight`
+
+`setHeight` looked up a toast's position in `this.toasts` (via `#findToastIdx`)
+and then used that integer to write into `this.heights`. The two arrays grow
+independently (`toasts` is unshifted, `heights` is pushed; `remove()` splices
+`toasts` but only `removeHeight()` filters `heights`), so the indices drift out
+of sync. When `toastIdx >= heights.length`, `this.heights[toastIdx] = data`
+created a sparse array with `undefined` holes, and a subsequent
+`heights.findIndex((h) => h.toastId === ...)` then dereferenced the hole and
+threw `TypeError: Cannot read properties of undefined (reading 'toastId')`,
+white-screening the host app.
+
+Fixed by searching `heights` directly by `toastId` (mirroring `removeHeight`)
+via a dedicated `#findHeightIdx` helper, so the index always refers to the
+correct array. The lookup is wrapped in `untrack` because `setHeight` runs
+inside a `$effect`; a tracked read of `this.heights` would re-trigger that
+effect on the following write and hit `effect_update_depth_exceeded`.

--- a/src/lib/toast-state.svelte.ts
+++ b/src/lib/toast-state.svelte.ts
@@ -31,6 +31,9 @@ class ToastState {
 		return idx;
 	};
 
+	#findHeightIdx = (toastId: number | string): number =>
+		this.heights.findIndex((height) => height.toastId === toastId);
+
 	addToast = (data: ToastT): void => {
 		if (!isBrowser) return;
 		this.toasts.unshift(data);
@@ -228,12 +231,16 @@ class ToastState {
 	};
 
 	setHeight = (data: HeightT) => {
-		const toastIdx = this.#findToastIdx(data.toastId);
-		if (toastIdx === null) {
-			this.heights.push(data);
-			return;
-		}
-		this.heights[toastIdx] = data;
+		// untrack: setHeight runs inside a $effect; a tracked read of this.heights
+		// would re-trigger it on the write below (effect_update_depth_exceeded).
+		untrack(() => {
+			const heightIdx = this.#findHeightIdx(data.toastId);
+			if (heightIdx === -1) {
+				this.heights.push(data);
+			} else {
+				this.heights[heightIdx] = data;
+			}
+		});
 	};
 
 	reset = () => {


### PR DESCRIPTION
Fixes #194. Supersedes #195. Credit to @leerobert for the original diagnosis and fix there; this carries it forward with the `#findToastIdx` refactor @wobsoriano asked for, since #195 has been idle.

## Root cause
`setHeight` looked up a toast's position in `this.toasts` (via `#findToastIdx`) and then used that same integer to index into `this.heights`:

```ts
setHeight = (data: HeightT) => {
	const toastIdx = this.#findToastIdx(data.toastId); // index into `toasts`
	if (toastIdx === null) {
		this.heights.push(data);
		return;
	}
	this.heights[toastIdx] = data; // ...but written into `heights`
};
```

The two arrays grow independently. `toasts` is `unshift`ed, `heights` is `push`ed, and `remove()` splices `toasts` while only `removeHeight()` filters `heights`, so the indices drift apart. Once `toastIdx >= heights.length`, the assignment `this.heights[toastIdx] = data` leaves a sparse array with `undefined` holes. A later `heights.findIndex((h) => h.toastId === ...)` in `Toast.svelte` then hits one of those holes and throws:

```
TypeError: Cannot read properties of undefined (reading 'toastId')
```

That `findIndex` runs in the toast render path, so the throw white-screens the whole host app. We caught this in production during a burst of rapidly created and dismissed error toasts. The stack trace bottoms out exactly at that `findIndex`.

## Fix
Search `heights` directly by `toastId`, the same way `removeHeight` already does, through a dedicated `#findHeightIdx` helper. Now the index always refers to the array it indexes into:

```ts
#findHeightIdx = (toastId: number | string): number =>
	this.heights.findIndex((height) => height.toastId === toastId);

setHeight = (data: HeightT) => {
	untrack(() => {
		const heightIdx = this.#findHeightIdx(data.toastId);
		if (heightIdx === -1) {
			this.heights.push(data);
		} else {
			this.heights[heightIdx] = data;
		}
	});
};
```

I left `#findToastIdx` alone instead of overloading one helper across both arrays. It searches `toasts` by `id`, and `remove()` correctly depends on that; reusing it for `heights` is what caused the bug in the first place. The two helpers are now symmetric. `#findToastIdx` and `remove` operate on `toasts`. `#findHeightIdx`, `removeHeight`, and `setHeight` operate on `heights`.

The `untrack` matters here. `setHeight` runs inside `Toast.svelte`'s height-measurement `$effect`, so without it the `findIndex` read subscribes that effect to `this.heights`, and the write right after re-triggers the effect into `effect_update_depth_exceeded`. That's the same failure @leerobert hit and fixed in #195's follow-up commit.

Changeset included (patch). Verified locally with `pnpm check` (svelte-check clean).
