### PR TITLE
fix: guard heightIndex against not-found (-1) result

### DIFF
--- a/.changeset/fix-heightindex-negative-one.md
+++ b/.changeset/fix-heightindex-negative-one.md
@@ -1,0 +1,13 @@
+---
+"svelte-sonner": patch
+---
+
+fix: guard `heightIndex` against a not-found (`-1`) result
+
+`Toast.svelte` computed `heightIndex` as `heights.findIndex(...) || 0`. When a
+toast has no measured height entry yet, `findIndex` returns `-1`, and `-1 || 0`
+evaluates to `-1` (since `-1` is truthy). That negative index then fed the
+offset calculation (`heightIndex * GAP`) and the `reducerIndex >= heightIndex`
+guard, producing incorrect stacking offsets in the brief window before a
+toast's height is measured. Replaced the `|| 0` fallback with an explicit
+`=== -1 ? 0 : idx` check.

--- a/src/lib/Toast.svelte
+++ b/src/lib/Toast.svelte
@@ -127,10 +127,13 @@
 	const toastClass = $derived(toast.class || '');
 	const toastDescriptionClass = $derived(toast.descriptionClass || '');
 	// height index is used to calculate the offset as it gets updated before the toast array, which means we can calculate the new layout faster.
-	const heightIndex = $derived(
-		toastState.heights.findIndex((height) => height.toastId === toast.id) ||
-			0
-	);
+	// findIndex returns -1 when not yet measured; -1 is truthy, so `|| 0` left a negative index in the offset math.
+	const heightIndex = $derived.by(() => {
+		const idx = toastState.heights.findIndex(
+			(height) => height.toastId === toast.id
+		);
+		return idx === -1 ? 0 : idx;
+	});
 	const closeButton = $derived(toast.closeButton ?? closeButtonFromToaster);
 	const duration = $derived(
 		toast.duration ?? durationFromToaster ?? TOAST_LIFETIME


### PR DESCRIPTION
Fixes #201.

`heightIndex` in `Toast.svelte` was computed as `heights.findIndex(...) || 0`. `findIndex` returns `-1` when a toast has no measured height entry yet (the frame before its height-measurement `$effect` runs), and since `-1` is truthy, `-1 || 0` evaluates to `-1`. That negative index then leaked into the offset math (`heightIndex * GAP`) and the `reducerIndex >= heightIndex` guard, so the toast got a wrong stacking offset during that window.

The fix replaces the `|| 0` fallback with an explicit `=== -1 ? 0 : idx` check via `$derived.by`.

This is a layout glitch, not a crash.

Changeset included (patch). Verified locally with `pnpm check` (svelte-check clean).
