### PR TITLE
Fix a batch of reported issues and catch up with upstream sonner

### DIFF
--- a/.changeset/native-global-styles.md
+++ b/.changeset/native-global-styles.md
@@ -1,0 +1,5 @@
+---
+'svelte-sonner': patch
+---
+
+fix: replace the svelte-preprocess `<style global>` block with a native Svelte 5 `:global` block so the published component compiles with the latest `@sveltejs/vite-plugin-svelte` (fixes crashes with `@tailwindcss/vite` CSS extraction)

--- a/.changeset/review-round-fixes.md
+++ b/.changeset/review-round-fixes.md
@@ -1,0 +1,5 @@
+---
+'svelte-sonner': patch
+---
+
+fix: record the drag start time so a fast flick below the distance threshold can dismiss a toast, reset the auto-close timer when a dismissed toast id is recreated in the same tick, keep height entries in newest-first order when several toasts mount together, and fully reset gesture state when a toast is revived mid-exit

--- a/.changeset/sync-upstream-777-fixes.md
+++ b/.changeset/sync-upstream-777-fixes.md
@@ -1,0 +1,5 @@
+---
+'svelte-sonner': patch
+---
+
+fix: port the bug-fix batch from upstream sonner (emilkowalski/sonner#777): custom icons no longer render twice in promise toasts, a fast flick no longer dismisses a toast in a direction not in `swipeDirections` (which is now actually passed down from the Toaster), decorative icons are hidden from assistive technology, toast content takes the full toast width, `toast.custom()` keeps an explicit id of `0`, toasts created before the `<Toaster />` mounts are no longer lost, a new toast reusing the id of a dismissed toast no longer inherits its props, and a toast recreated right after being dismissed is no longer removed by the pending dismissal

--- a/.changeset/toaster-id-and-gap.md
+++ b/.changeset/toaster-id-and-gap.md
@@ -1,0 +1,5 @@
+---
+'svelte-sonner': minor
+---
+
+feat: support multiple toasters via `<Toaster id="..." />` and `toast(..., { toasterId })` (matching upstream sonner semantics: a toaster without an `id` renders only toasts without a `toasterId`), use the `gap` prop in the toast offset math instead of a hardcoded value, and honor `toastOptions.closeButton`. Note: an `id` passed to `<Toaster />` now identifies the toaster instead of landing on the `<ol>` element

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ node_modules
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 .vscode
+
+# Playwright output
+test-results
+playwright-report

--- a/README.md
+++ b/README.md
@@ -370,6 +370,22 @@ toast('Event has been created', {
 });
 ```
 
+## Multiple toasters
+
+Give a toaster an `id` and target it with the `toasterId` option. A toaster without an `id` renders only the toasts created without a `toasterId`.
+
+```svelte
+<Toaster />
+<Toaster id="top" position="top-center" />
+```
+
+```js
+toast('Renders in the default toaster');
+toast('Renders in the top toaster', { toasterId: 'top' });
+```
+
+`toast.dismiss()` with no arguments dismisses toasts across all toasters. Note that `id` identifies the toaster and is no longer forwarded to the rendered `<ol>` element.
+
 ## Keyboard focus
 
 You can focus on the toast area by pressing ⌥/alt + T. You can override it by providing an array of `event.code` values for each key.

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
 		"publint": "^0.2.12",
 		"svelte": "^5.43.5",
 		"svelte-check": "^4.3.3",
-		"svelte-preprocess": "^6.0.3",
 		"tslib": "^2.8.1",
 		"typescript": "^5.9.3",
 		"typescript-eslint": "^8.46.3",
@@ -87,8 +86,7 @@
 	"pnpm": {
 		"onlyBuiltDependencies": [
 			"@sveltejs/kit",
-			"esbuild",
-			"svelte-preprocess"
+			"esbuild"
 		]
 	},
 	"sideEffects": false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,9 +93,6 @@ importers:
       svelte-check:
         specifier: ^4.3.3
         version: 4.3.3(picomatch@4.0.2)(svelte@5.43.5)(typescript@5.9.3)
-      svelte-preprocess:
-        specifier: ^6.0.3
-        version: 6.0.3(postcss-load-config@3.1.4(postcss@8.5.4))(postcss@8.5.4)(sass@1.67.0)(svelte@5.43.5)(typescript@5.9.3)
       tslib:
         specifier: ^2.8.1
         version: 2.8.1
@@ -1917,43 +1914,6 @@ packages:
       svelte: ^3.37.0 || ^4.0.0 || ^5.0.0
     peerDependenciesMeta:
       svelte:
-        optional: true
-
-  svelte-preprocess@6.0.3:
-    resolution: {integrity: sha512-PLG2k05qHdhmRG7zR/dyo5qKvakhm8IJ+hD2eFRQmMLHp7X3eJnjeupUtvuRpbNiF31RjVw45W+abDwHEmP5OA==}
-    engines: {node: '>= 18.0.0'}
-    peerDependencies:
-      '@babel/core': ^7.10.2
-      coffeescript: ^2.5.1
-      less: ^3.11.3 || ^4.0.0
-      postcss: ^7 || ^8
-      postcss-load-config: '>=3'
-      pug: ^3.0.0
-      sass: ^1.26.8
-      stylus: '>=0.55'
-      sugarss: ^2.0.0 || ^3.0.0 || ^4.0.0
-      svelte: ^4.0.0 || ^5.0.0-next.100 || ^5.0.0
-      typescript: ^5.0.0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      coffeescript:
-        optional: true
-      less:
-        optional: true
-      postcss:
-        optional: true
-      postcss-load-config:
-        optional: true
-      pug:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      typescript:
         optional: true
 
   svelte-toolbelt@0.7.1:
@@ -4061,15 +4021,6 @@ snapshots:
       postcss-selector-parser: 7.1.0
     optionalDependencies:
       svelte: 5.43.5
-
-  svelte-preprocess@6.0.3(postcss-load-config@3.1.4(postcss@8.5.4))(postcss@8.5.4)(sass@1.67.0)(svelte@5.43.5)(typescript@5.9.3):
-    dependencies:
-      svelte: 5.43.5
-    optionalDependencies:
-      postcss: 8.5.4
-      postcss-load-config: 3.1.4(postcss@8.5.4)
-      sass: 1.67.0
-      typescript: 5.9.3
 
   svelte-toolbelt@0.7.1(svelte@5.43.5):
     dependencies:

--- a/scripts/setupTest.ts
+++ b/scripts/setupTest.ts
@@ -93,6 +93,11 @@ vi.mock('$app/stores', (): typeof stores => {
 
 Element.prototype.scrollIntoView = () => {};
 
+// jsdom doesn't implement the pointer capture API
+Element.prototype.setPointerCapture = () => {};
+Element.prototype.releasePointerCapture = () => {};
+Element.prototype.hasPointerCapture = () => false;
+
 export const mediaQueryState = {
 	matches: false
 };

--- a/src/lib/Toast.svelte
+++ b/src/lib/Toast.svelte
@@ -206,10 +206,8 @@
 		offsetBeforeRemove = offset;
 
 		toastState.removeHeight(toast.id);
-
-		setTimeout(() => {
-			toastState.remove(toast.id);
-		}, TIME_BEFORE_UNMOUNT);
+		toastState.markDismissed(toast.id);
+		toastState.scheduleRemoval(toast.id, TIME_BEFORE_UNMOUNT);
 	}
 
 	let timeoutId: ReturnType<typeof setTimeout>;
@@ -279,8 +277,32 @@
 	$effect(() => {
 		if (toast.delete) {
 			untrack(() => {
+				// `markDismissed` flips `delete` for dismissals that already ran
+				// `deleteToast` themselves (close button, swipe, auto-close) — don't
+				// re-enter and double-fire `onDismiss`.
+				if (removed) return;
 				deleteToast();
 				toast.onDismiss?.(toast);
+			});
+		}
+	});
+
+	// The toast was recreated with the same id while this instance's exit animation
+	// was running (`create` cancelled the pending removal). The keyed each reuses
+	// this component instance, so revive its local exit state.
+	$effect(() => {
+		if (!toast.delete && !toast.dismiss && removed) {
+			untrack(() => {
+				removed = false;
+				swipeOut = false;
+				isSwiped = false;
+				swiping = false;
+				clearTimeout(timeoutId);
+				remainingTime = duration;
+				if (!isPromiseLoadingOrInfiniteDuration) {
+					startTimer();
+				}
+				toastState.setHeight({ toastId: toast.id, height: initialHeight });
 			});
 		}
 	});

--- a/src/lib/Toast.svelte
+++ b/src/lib/Toast.svelte
@@ -302,8 +302,8 @@
 		if (toast.delete) {
 			untrack(() => {
 				// `markDismissed` flips `delete` for dismissals that already ran
-				// `deleteToast` themselves (close button, swipe, auto-close) — don't
-				// re-enter and double-fire `onDismiss`.
+				// `deleteToast` themselves (close button, swipe, auto-close), so
+				// don't re-enter and double-fire `onDismiss`.
 				if (removed) return;
 				deleteToast();
 				toast.onDismiss?.(toast);

--- a/src/lib/Toast.svelte
+++ b/src/lib/Toast.svelte
@@ -233,6 +233,10 @@
 	);
 
 	function startTimer() {
+		// Both the timer effect and the `updated` effect can start a timer in the
+		// same flush (a recreated toast mounts with `updated` already set); clear
+		// first so only one runs.
+		clearTimeout(timeoutId);
 		closeTimerStartTime = new Date().getTime();
 		// let the toast know it has started
 		timeoutId = setTimeout(() => {
@@ -321,6 +325,12 @@
 				swipeOut = false;
 				isSwiped = false;
 				swiping = false;
+				swipeDirection = null;
+				swipeOutDirection = null;
+				pointerStart = null;
+				dragStartTime = null;
+				toastRef?.style.removeProperty('--swipe-amount-x');
+				toastRef?.style.removeProperty('--swipe-amount-y');
 				clearTimeout(timeoutId);
 				remainingTime = duration;
 				if (!isPromiseLoadingOrInfiniteDuration) {
@@ -339,6 +349,7 @@
 	const handlePointerDown: PointerEventHandler<HTMLLIElement> = (event) => {
 		if (disabled) return;
 
+		dragStartTime = new Date();
 		offsetBeforeRemove = offset;
 		const target = event.target as HTMLElement;
 

--- a/src/lib/Toast.svelte
+++ b/src/lib/Toast.svelte
@@ -94,6 +94,7 @@
 		closeIcon,
 		infoIcon,
 		defaultRichColors = false,
+		gap = GAP,
 		swipeDirections: swipeDirectionsProp,
 		closeButtonAriaLabel,
 		pauseWhenPageIsHidden,
@@ -127,9 +128,17 @@
 	const toastClass = $derived(toast.class || '');
 	const toastDescriptionClass = $derived(toast.descriptionClass || '');
 	// height index is used to calculate the offset as it gets updated before the toast array, which means we can calculate the new layout faster.
+	// Only the heights of this toaster + position matter for the offset math,
+	// otherwise toasts of another toaster (or another corner) push these around.
+	const relevantHeights = $derived(
+		toastState.heights.filter(
+			(height) =>
+				height.toasterId === toast.toasterId && height.position === position
+		)
+	);
 	// findIndex returns -1 when not yet measured; -1 is truthy, so `|| 0` left a negative index in the offset math.
 	const heightIndex = $derived.by(() => {
-		const idx = toastState.heights.findIndex(
+		const idx = relevantHeights.findIndex(
 			(height) => height.toastId === toast.id
 		);
 		return idx === -1 ? 0 : idx;
@@ -144,7 +153,7 @@
 		swipeDirectionsProp ?? getDefaultSwipeDirections(position)
 	);
 	const toastsHeightBefore = $derived(
-		toastState.heights.reduce((prev, curr, reducerIndex) => {
+		relevantHeights.reduce((prev, curr, reducerIndex) => {
 			if (reducerIndex >= heightIndex) return prev;
 			return prev + curr.height;
 		}, 0)
@@ -161,7 +170,7 @@
 	let closeTimerStartTime = $state(0);
 	let lastCloseTimerStartTime = $state(0);
 
-	const offset = $derived(Math.round(heightIndex * GAP + toastsHeightBefore));
+	const offset = $derived(Math.round(heightIndex * gap + toastsHeightBefore));
 
 	$effect(() => {
 		toastTitle;
@@ -181,7 +190,7 @@
 		const offsetHeight = toastEl.offsetHeight;
 		const rectHeight = toastEl.getBoundingClientRect().height;
 		const scaledRectHeight =
-			Math.round((rectHeight / scale + Number.EPSILON) & 100) / 100;
+			Math.round((rectHeight / scale + Number.EPSILON) * 100) / 100;
 
 		toastEl.style.removeProperty('height');
 
@@ -197,7 +206,12 @@
 
 		initialHeight = finalHeight;
 
-		toastState.setHeight({ toastId: toast.id, height: finalHeight });
+		toastState.setHeight({
+			toastId: toast.id,
+			height: finalHeight,
+			toasterId: toast.toasterId,
+			position
+		});
 	});
 
 	function deleteToast() {
@@ -267,7 +281,12 @@
 		const height = toastRef?.getBoundingClientRect().height as number;
 
 		initialHeight = height;
-		toastState.setHeight({ toastId: toast.id, height });
+		toastState.setHeight({
+			toastId: toast.id,
+			height,
+			toasterId: toast.toasterId,
+			position
+		});
 
 		return () => {
 			toastState.removeHeight(toast.id);
@@ -302,7 +321,12 @@
 				if (!isPromiseLoadingOrInfiniteDuration) {
 					startTimer();
 				}
-				toastState.setHeight({ toastId: toast.id, height: initialHeight });
+				toastState.setHeight({
+					toastId: toast.id,
+					height: initialHeight,
+					toasterId: toast.toasterId,
+					position
+				});
 			});
 		}
 	});

--- a/src/lib/Toast.svelte
+++ b/src/lib/Toast.svelte
@@ -133,7 +133,8 @@
 	const relevantHeights = $derived(
 		toastState.heights.filter(
 			(height) =>
-				height.toasterId === toast.toasterId && height.position === position
+				height.toasterId === toast.toasterId &&
+				height.position === position
 		)
 	);
 	// findIndex returns -1 when not yet measured; -1 is truthy, so `|| 0` left a negative index in the offset math.
@@ -265,7 +266,11 @@
 
 	$effect(() => {
 		if (!isPromiseLoadingOrInfiniteDuration) {
-			if (expanded || interacting || (pauseWhenPageIsHidden && isDocumentHidden.current)) {
+			if (
+				expanded ||
+				interacting ||
+				(pauseWhenPageIsHidden && isDocumentHidden.current)
+			) {
 				pauseTimer();
 			} else {
 				startTimer();
@@ -592,7 +597,10 @@
 				{/if}
 			</div>
 		{/if}
-		<div data-content="" class={cn(classes?.content, toast?.classes?.content)}>
+		<div
+			data-content=""
+			class={cn(classes?.content, toast?.classes?.content)}
+		>
 			<div
 				data-title=""
 				class={cn(classes?.title, toast?.classes?.title)}

--- a/src/lib/Toast.svelte
+++ b/src/lib/Toast.svelte
@@ -140,6 +140,9 @@
 	);
 	let pointerStart: { x: number; y: number } | null = null;
 	const coords = $derived(position.split('-'));
+	const swipeDirections = $derived(
+		swipeDirectionsProp ?? getDefaultSwipeDirections(position)
+	);
 	const toastsHeightBefore = $derived(
 		toastState.heights.reduce((prev, curr, reducerIndex) => {
 			if (reducerIndex >= heightIndex) return prev;
@@ -316,8 +319,19 @@
 			swipeDirection === 'x' ? swipeAmountX : swipeAmountY;
 		const velocity = Math.abs(swipeAmount) / timeTaken;
 
+		// Movement towards a direction that isn't allowed is dampened, not blocked,
+		// so a fast flick can still pass the velocity check. Only dismiss if the
+		// direction is allowed.
+		const isAllowedDirection =
+			swipeDirection === 'x'
+				? swipeDirections.includes(swipeAmountX > 0 ? 'right' : 'left')
+				: swipeDirections.includes(swipeAmountY > 0 ? 'bottom' : 'top');
+
 		// remove only if threshold is met
-		if (Math.abs(swipeAmount) >= SWIPE_THRESHOLD || velocity > 0.11) {
+		if (
+			isAllowedDirection &&
+			(Math.abs(swipeAmount) >= SWIPE_THRESHOLD || velocity > 0.11)
+		) {
 			offsetBeforeRemove = offset;
 			toast.onDismiss?.(toast);
 
@@ -348,9 +362,6 @@
 
 		const yDelta = event.clientY - pointerStart.y;
 		const xDelta = event.clientX - pointerStart.x;
-
-		const swipeDirections =
-			swipeDirectionsProp ?? getDefaultSwipeDirections(position);
 
 		// Determine swipe direction if not already locked
 		if (!swipeDirection && (Math.abs(xDelta) > 1 || Math.abs(yDelta) > 1)) {
@@ -510,14 +521,17 @@
 	{:else}
 		{#if (toastType || toast.icon || toast.promise) && toast.icon !== null && (icon !== null || toast.icon)}
 			<div data-icon="" class={cn(classes?.icon, toast?.classes?.icon)}>
-				{#if toast.promise || toastType === 'loading'}
+				<!-- Promise toasts keep the loader mounted after they settle so it can animate out -->
+				{#if toastType === 'loading'}
 					{#if toast.icon}
 						<toast.icon />
 					{:else}
 						{@render LoadingIcon()}
 					{/if}
+				{:else if toast.promise}
+					{@render LoadingIcon()}
 				{/if}
-				{#if toast.type !== 'loading'}
+				{#if toastType !== 'loading'}
 					{#if toast.icon}
 						<toast.icon />
 					{:else if toastType === 'success'}

--- a/src/lib/Toaster.svelte
+++ b/src/lib/Toaster.svelte
@@ -110,6 +110,7 @@
 	}
 
 	let {
+		id,
 		invert = false,
 		position = 'bottom-right',
 		hotkey = ['altKey', 'KeyT'],
@@ -169,12 +170,20 @@
 		return dirAttribute;
 	}
 
+	// The slice of the shared toast state this toaster renders: an id-less toaster
+	// shows only toasts without a toasterId (upstream sonner semantics).
+	const filteredToasts = $derived(
+		id
+			? toastState.toasts.filter((toast) => toast.toasterId === id)
+			: toastState.toasts.filter((toast) => !toast.toasterId)
+	);
+
 	const possiblePositions = $derived(
 		Array.from(
 			new Set(
 				[
 					position,
-					...toastState.toasts
+					...filteredToasts
 						.filter((toast) => toast.position)
 						.map((toast) => toast.position)
 				].filter(Boolean)
@@ -194,14 +203,14 @@
 	);
 
 	$effect(() => {
-		if (toastState.toasts.length <= 1) {
+		if (filteredToasts.length <= 1) {
 			expanded = false;
 		}
 	});
 
 	// Check for dismissed toasts and remove them. We need to do this to have dismiss animation.
 	$effect(() => {
-		const toastsToDismiss = toastState.toasts.filter(
+		const toastsToDismiss = filteredToasts.filter(
 			(toast) => toast.dismiss && !toast.delete
 		);
 
@@ -369,10 +378,13 @@
 	aria-relevant="additions text"
 	aria-atomic="false"
 >
-	{#if toastState.toasts.length > 0}
+	{#if filteredToasts.length > 0}
 		{#each possiblePositions as position, index (position)}
 			{@const [y, x] = position.split('-')}
 			{@const offsetObject = getOffsetObject(offset, mobileOffset)}
+			{@const frontHeight = toastState.heights.find(
+				(height) => height.toasterId === id && height.position === position
+			)?.height ?? 0}
 			<!-- eslint-disable-next-line svelte/valid-compile -->
 			<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
 			<ol
@@ -384,7 +396,7 @@
 				data-sonner-theme={actualTheme}
 				data-y-position={y}
 				data-x-position={x}
-				style:--front-toast-height={`${toastState.heights[0]?.height}px`}
+				style:--front-toast-height={`${frontHeight}px`}
 				style:--width={`${TOAST_WIDTH}px`}
 				style:--gap={`${gap}px`}
 				style:--offset-top={offsetObject['--offset-top']}
@@ -412,7 +424,7 @@
 				onpointerup={handlePointerUp}
 				{...restProps}
 			>
-				{#each toastState.toasts.filter((toast) => (!toast.position && index === 0) || toast.position === position) as toast, index (toast.id)}
+				{#each filteredToasts.filter((toast) => (!toast.position && index === 0) || toast.position === position) as toast, index (toast.id)}
 					<Toast
 						{index}
 						{toast}
@@ -422,9 +434,10 @@
 						descriptionClass={toastOptions?.descriptionClass || ''}
 						{invert}
 						{visibleToasts}
-						{closeButton}
+						closeButton={toastOptions?.closeButton ?? closeButton}
 						{interacting}
 						{position}
+						{gap}
 						style={toastOptions?.style ?? ''}
 						classes={toastOptions.classes || {}}
 						unstyled={toastOptions.unstyled ?? false}

--- a/src/lib/Toaster.svelte
+++ b/src/lib/Toaster.svelte
@@ -499,7 +499,8 @@
 	{/if}
 </section>
 
-<style global lang="postcss">
+<style>
+	:global {
 	html[dir='ltr'],
 	[data-sonner-toaster][dir='ltr'] {
 		--toast-icon-margin-start: -3px;
@@ -916,7 +917,7 @@
 		animation-name: swipe-out-down;
 	}
 
-	@keyframes swipe-out-left {
+	@keyframes -global-swipe-out-left {
 		from {
 			transform: var(--y) translateX(var(--swipe-amount-x));
 			opacity: 1;
@@ -928,7 +929,7 @@
 		}
 	}
 
-	@keyframes swipe-out-right {
+	@keyframes -global-swipe-out-right {
 		from {
 			transform: var(--y) translateX(var(--swipe-amount-x));
 			opacity: 1;
@@ -940,7 +941,7 @@
 		}
 	}
 
-	@keyframes swipe-out-up {
+	@keyframes -global-swipe-out-up {
 		from {
 			transform: var(--y) translateY(var(--swipe-amount-y));
 			opacity: 1;
@@ -952,7 +953,7 @@
 		}
 	}
 
-	@keyframes swipe-out-down {
+	@keyframes -global-swipe-out-down {
 		from {
 			transform: var(--y) translateY(var(--swipe-amount-y));
 			opacity: 1;
@@ -1221,7 +1222,7 @@
 		transform: rotate(330deg) translate(146%);
 	}
 
-	@keyframes sonner-fade-in {
+	@keyframes -global-sonner-fade-in {
 		0% {
 			opacity: 0;
 			transform: scale(0.8);
@@ -1232,7 +1233,7 @@
 		}
 	}
 
-	@keyframes sonner-fade-out {
+	@keyframes -global-sonner-fade-out {
 		0% {
 			opacity: 1;
 			transform: scale(1);
@@ -1243,7 +1244,7 @@
 		}
 	}
 
-	@keyframes sonner-spin {
+	@keyframes -global-sonner-spin {
 		0% {
 			opacity: 1;
 		}
@@ -1275,5 +1276,6 @@
 	.sonner-loader[data-visible='false'] {
 		opacity: 0;
 		transform: scale(0.8) translate(-50%, -50%);
+	}
 	}
 </style>

--- a/src/lib/Toaster.svelte
+++ b/src/lib/Toaster.svelte
@@ -232,8 +232,6 @@
 	});
 
 	onMount(() => {
-		toastState.reset();
-
 		const handleKeydown = (event: KeyboardEvent) => {
 			const isHotkeyPressed = hotkey.every(
 				(key) =>

--- a/src/lib/Toaster.svelte
+++ b/src/lib/Toaster.svelte
@@ -124,6 +124,7 @@
 		toastOptions = {},
 		dir = 'auto',
 		gap = GAP,
+		swipeDirections,
 		pauseWhenPageIsHidden = false,
 		loadingIcon: loadingIconProp,
 		successIcon: successIconProp,
@@ -437,6 +438,7 @@
 							closeButtonAriaLabel}
 						expandByDefault={expand}
 						{expanded}
+						{swipeDirections}
 						{pauseWhenPageIsHidden}
 						loadingIcon={loadingIconProp}
 					>
@@ -685,6 +687,10 @@
 		display: flex;
 		flex-direction: column;
 		gap: 2px;
+		/* Take the space the icon and the buttons leave, so a custom title or
+		   description isn't limited to the width of its text */
+		flex: 1;
+		min-width: 0;
 	}
 
 	[data-sonner-toast][data-styled='true'] [data-button] {

--- a/src/lib/Toaster.svelte
+++ b/src/lib/Toaster.svelte
@@ -382,9 +382,11 @@
 		{#each possiblePositions as position, index (position)}
 			{@const [y, x] = position.split('-')}
 			{@const offsetObject = getOffsetObject(offset, mobileOffset)}
-			{@const frontHeight = toastState.heights.find(
-				(height) => height.toasterId === id && height.position === position
-			)?.height ?? 0}
+			{@const frontHeight =
+				toastState.heights.find(
+					(height) =>
+						height.toasterId === id && height.position === position
+				)?.height ?? 0}
 			<!-- eslint-disable-next-line svelte/valid-compile -->
 			<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
 			<ol
@@ -501,781 +503,787 @@
 
 <style>
 	:global {
-	html[dir='ltr'],
-	[data-sonner-toaster][dir='ltr'] {
-		--toast-icon-margin-start: -3px;
-		--toast-icon-margin-end: 4px;
-		--toast-svg-margin-start: -1px;
-		--toast-svg-margin-end: 0px;
-		--toast-button-margin-start: auto;
-		--toast-button-margin-end: 0;
-		--toast-close-button-start: 0;
-		--toast-close-button-end: unset;
-		--toast-close-button-transform: translate(-35%, -35%);
-	}
-
-	html[dir='rtl'],
-	[data-sonner-toaster][dir='rtl'] {
-		--toast-icon-margin-start: 4px;
-		--toast-icon-margin-end: -3px;
-		--toast-svg-margin-start: 0px;
-		--toast-svg-margin-end: -1px;
-		--toast-button-margin-start: 0;
-		--toast-button-margin-end: auto;
-		--toast-close-button-start: unset;
-		--toast-close-button-end: 0;
-		--toast-close-button-transform: translate(35%, -35%);
-	}
-
-	[data-sonner-toaster] {
-		position: fixed;
-		width: var(--width);
-		font-family:
-			ui-sans-serif,
-			system-ui,
-			-apple-system,
-			BlinkMacSystemFont,
-			Segoe UI,
-			Roboto,
-			Helvetica Neue,
-			Arial,
-			Noto Sans,
-			sans-serif,
-			Apple Color Emoji,
-			Segoe UI Emoji,
-			Segoe UI Symbol,
-			Noto Color Emoji;
-		--gray1: hsl(0, 0%, 99%);
-		--gray2: hsl(0, 0%, 97.3%);
-		--gray3: hsl(0, 0%, 95.1%);
-		--gray4: hsl(0, 0%, 93%);
-		--gray5: hsl(0, 0%, 90.9%);
-		--gray6: hsl(0, 0%, 88.7%);
-		--gray7: hsl(0, 0%, 85.8%);
-		--gray8: hsl(0, 0%, 78%);
-		--gray9: hsl(0, 0%, 56.1%);
-		--gray10: hsl(0, 0%, 52.3%);
-		--gray11: hsl(0, 0%, 43.5%);
-		--gray12: hsl(0, 0%, 9%);
-		--border-radius: 8px;
-		box-sizing: border-box;
-		padding: 0;
-		margin: 0;
-		list-style: none;
-		outline: none;
-		z-index: 999999999;
-		transition: transform 400ms ease;
-	}
-
-	@media (hover: none) and (pointer: coarse) {
-		[data-sonner-toaster][data-lifted='true'] {
-			transform: none;
-		}
-	}
-
-	[data-sonner-toaster][data-x-position='right'] {
-		right: var(--offset-right);
-	}
-
-	[data-sonner-toaster][data-x-position='left'] {
-		left: var(--offset-left);
-	}
-
-	[data-sonner-toaster][data-x-position='center'] {
-		left: 50%;
-		transform: translateX(-50%);
-	}
-
-	[data-sonner-toaster][data-y-position='top'] {
-		top: var(--offset-top);
-	}
-
-	[data-sonner-toaster][data-y-position='bottom'] {
-		bottom: var(--offset-bottom);
-	}
-
-	[data-sonner-toast] {
-		--y: translateY(100%);
-		--lift-amount: calc(var(--lift) * var(--gap));
-		z-index: var(--z-index);
-		position: absolute;
-		opacity: 0;
-		transform: var(--y);
-		touch-action: none;
-		transition:
-			transform 400ms,
-			opacity 400ms,
-			height 400ms,
-			box-shadow 200ms;
-		box-sizing: border-box;
-		outline: none;
-		overflow-wrap: anywhere;
-	}
-
-	[data-sonner-toast][data-styled='true'] {
-		padding: 16px;
-		background: var(--normal-bg);
-		border: 1px solid var(--normal-border);
-		color: var(--normal-text);
-		border-radius: var(--border-radius);
-		box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.1);
-		width: var(--width);
-		font-size: 13px;
-		display: flex;
-		align-items: center;
-		gap: 6px;
-	}
-
-	[data-sonner-toast]:focus-visible {
-		box-shadow:
-			0px 4px 12px rgba(0, 0, 0, 0.1),
-			0 0 0 2px rgba(0, 0, 0, 0.2);
-	}
-
-	[data-sonner-toast][data-y-position='top'] {
-		top: 0;
-		--y: translateY(-100%);
-		--lift: 1;
-		--lift-amount: calc(1 * var(--gap));
-	}
-
-	[data-sonner-toast][data-y-position='bottom'] {
-		bottom: 0;
-		--y: translateY(100%);
-		--lift: -1;
-		--lift-amount: calc(var(--lift) * var(--gap));
-	}
-
-	[data-sonner-toast][data-styled='true'] [data-description] {
-		font-weight: 400;
-		line-height: 1.4;
-		color: #3f3f3f;
-	}
-
-	[data-rich-colors='true'][data-sonner-toast][data-styled='true']
-		[data-description] {
-		color: inherit;
-	}
-
-	[data-sonner-toaster][data-sonner-theme='dark'] [data-description] {
-		color: hsl(0, 0%, 91%);
-	}
-
-	[data-sonner-toast][data-styled='true'] [data-title] {
-		font-weight: 500;
-		line-height: 1.5;
-		color: inherit;
-	}
-
-	[data-sonner-toast][data-styled='true'] [data-icon] {
-		display: flex;
-		height: 16px;
-		width: 16px;
-		position: relative;
-		justify-content: flex-start;
-		align-items: center;
-		flex-shrink: 0;
-		margin-left: var(--toast-icon-margin-start);
-		margin-right: var(--toast-icon-margin-end);
-	}
-
-	[data-sonner-toast][data-promise='true'] [data-icon] > svg {
-		opacity: 0;
-		transform: scale(0.8);
-		transform-origin: center;
-		animation: sonner-fade-in 300ms ease forwards;
-	}
-
-	[data-sonner-toast][data-styled='true'] [data-icon] > * {
-		flex-shrink: 0;
-	}
-
-	[data-sonner-toast][data-styled='true'] [data-icon] svg {
-		margin-left: var(--toast-svg-margin-start);
-		margin-right: var(--toast-svg-margin-end);
-	}
-
-	[data-sonner-toast][data-styled='true'] [data-content] {
-		display: flex;
-		flex-direction: column;
-		gap: 2px;
-		/* Take the space the icon and the buttons leave, so a custom title or
-		   description isn't limited to the width of its text */
-		flex: 1;
-		min-width: 0;
-	}
-
-	[data-sonner-toast][data-styled='true'] [data-button] {
-		border-radius: 4px;
-		padding-left: 8px;
-		padding-right: 8px;
-		height: 24px;
-		font-size: 12px;
-		color: var(--normal-bg);
-		background: var(--normal-text);
-		margin-left: var(--toast-button-margin-start);
-		margin-right: var(--toast-button-margin-end);
-		border: none;
-		font-weight: 500;
-		cursor: pointer;
-		outline: none;
-		display: flex;
-		align-items: center;
-		flex-shrink: 0;
-		transition:
-			opacity 400ms,
-			box-shadow 200ms;
-	}
-
-	[data-sonner-toast][data-styled='true'] [data-button]:focus-visible {
-		box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.4);
-	}
-
-	[data-sonner-toast][data-styled='true'] [data-button]:first-of-type {
-		margin-left: var(--toast-button-margin-start);
-		margin-right: var(--toast-button-margin-end);
-	}
-
-	[data-sonner-toast][data-styled='true'] [data-cancel] {
-		color: var(--normal-text);
-		background: rgba(0, 0, 0, 0.08);
-	}
-
-	[data-sonner-toaster][data-sonner-theme='dark']
-		[data-sonner-toast][data-styled='true']
-		[data-cancel] {
-		background: rgba(255, 255, 255, 0.3);
-	}
-
-	[data-sonner-toast][data-styled='true'] [data-close-button] {
-		position: absolute;
-		left: var(--toast-close-button-start);
-		right: var(--toast-close-button-end);
-		top: 0;
-		height: 20px;
-		width: 20px;
-		display: flex;
-		justify-content: center;
-		align-items: center;
-		padding: 0;
-		color: var(--gray12);
-		background: var(--normal-bg);
-		border: 1px solid var(--gray4);
-		transform: var(--toast-close-button-transform);
-		border-radius: 50%;
-		cursor: pointer;
-		z-index: 1;
-		transition:
-			opacity 100ms,
-			background 200ms,
-			border-color 200ms;
-	}
-
-	[data-sonner-toast][data-styled='true'] [data-close-button]:focus-visible {
-		box-shadow:
-			0px 4px 12px rgba(0, 0, 0, 0.1),
-			0 0 0 2px rgba(0, 0, 0, 0.2);
-	}
-
-	[data-sonner-toast][data-styled='true'] [data-disabled='true'] {
-		cursor: not-allowed;
-	}
-
-	[data-sonner-toast][data-styled='true']:hover [data-close-button]:hover {
-		background: var(--gray2);
-		border-color: var(--gray5);
-	}
-
-	[data-sonner-toast][data-swiping='true']::before {
-		content: '';
-		position: absolute;
-		left: -100%;
-		right: -100%;
-		height: 100%;
-		z-index: -1;
-	}
-
-	[data-sonner-toast][data-y-position='top'][data-swiping='true']::before {
-		bottom: 50%;
-		transform: scaleY(3) translateY(50%);
-	}
-
-	[data-sonner-toast][data-y-position='bottom'][data-swiping='true']::before {
-		top: 50%;
-		transform: scaleY(3) translateY(-50%);
-	}
-
-	[data-sonner-toast][data-swiping='false'][data-removed='true']::before {
-		content: '';
-		position: absolute;
-		inset: 0;
-		transform: scaleY(2);
-	}
-
-	[data-sonner-toast][data-expanded='true']::after {
-		content: '';
-		position: absolute;
-		left: 0;
-		height: calc(var(--gap) + 1px);
-		bottom: 100%;
-		width: 100%;
-	}
-
-	[data-sonner-toast][data-mounted='true'] {
-		--y: translateY(0);
-		opacity: 1;
-	}
-
-	[data-sonner-toast][data-expanded='false'][data-front='false'] {
-		--scale: var(--toasts-before) * 0.05 + 1;
-		--y: translateY(calc(var(--lift-amount) * var(--toasts-before)))
-			scale(calc(-1 * var(--scale)));
-		height: var(--front-toast-height);
-	}
-
-	[data-sonner-toast] > * {
-		transition: opacity 400ms;
-	}
-
-	[data-sonner-toast][data-x-position='right'] {
-		right: 0;
-	}
-
-	[data-sonner-toast][data-x-position='left'] {
-		left: 0;
-	}
-
-	[data-sonner-toast][data-expanded='false'][data-front='false'][data-styled='true']
-		> * {
-		opacity: 0;
-	}
-
-	[data-sonner-toast][data-visible='false'] {
-		opacity: 0;
-		pointer-events: none;
-	}
-
-	[data-sonner-toast][data-mounted='true'][data-expanded='true'] {
-		--y: translateY(calc(var(--lift) * var(--offset)));
-		height: var(--initial-height);
-	}
-
-	[data-sonner-toast][data-removed='true'][data-front='true'][data-swipe-out='false'] {
-		--y: translateY(calc(var(--lift) * -100%));
-		opacity: 0;
-	}
-
-	[data-sonner-toast][data-removed='true'][data-front='false'][data-swipe-out='false'][data-expanded='true'] {
-		--y: translateY(
-			calc(var(--lift) * var(--offset) + var(--lift) * -100%)
-		);
-		opacity: 0;
-	}
-
-	[data-sonner-toast][data-removed='true'][data-front='false'][data-swipe-out='false'][data-expanded='false'] {
-		--y: translateY(40%);
-		opacity: 0;
-		transition:
-			transform 500ms,
-			opacity 200ms;
-	}
-
-	[data-sonner-toast][data-removed='true'][data-front='false']::before {
-		height: calc(var(--initial-height) + 20%);
-	}
-
-	[data-sonner-toast][data-swiping='true'] {
-		transform: var(--y) translateY(var(--swipe-amount-y, 0px))
-			translateX(var(--swipe-amount-x, 0px));
-		transition: none;
-	}
-
-	[data-sonner-toast][data-swiped='true'] {
-		user-select: none;
-	}
-
-	[data-sonner-toast][data-swipe-out='true'][data-y-position='bottom'],
-	[data-sonner-toast][data-swipe-out='true'][data-y-position='top'] {
-		animation-duration: 200ms;
-		animation-timing-function: ease-out;
-		animation-fill-mode: forwards;
-	}
-
-	[data-sonner-toast][data-swipe-out='true'][data-swipe-direction='left'] {
-		animation-name: swipe-out-left;
-	}
-
-	[data-sonner-toast][data-swipe-out='true'][data-swipe-direction='right'] {
-		animation-name: swipe-out-right;
-	}
-
-	[data-sonner-toast][data-swipe-out='true'][data-swipe-direction='up'] {
-		animation-name: swipe-out-up;
-	}
-
-	[data-sonner-toast][data-swipe-out='true'][data-swipe-direction='down'] {
-		animation-name: swipe-out-down;
-	}
-
-	@keyframes -global-swipe-out-left {
-		from {
-			transform: var(--y) translateX(var(--swipe-amount-x));
-			opacity: 1;
+		html[dir='ltr'],
+		[data-sonner-toaster][dir='ltr'] {
+			--toast-icon-margin-start: -3px;
+			--toast-icon-margin-end: 4px;
+			--toast-svg-margin-start: -1px;
+			--toast-svg-margin-end: 0px;
+			--toast-button-margin-start: auto;
+			--toast-button-margin-end: 0;
+			--toast-close-button-start: 0;
+			--toast-close-button-end: unset;
+			--toast-close-button-transform: translate(-35%, -35%);
 		}
 
-		to {
-			transform: var(--y) translateX(calc(var(--swipe-amount-x) - 100%));
-			opacity: 0;
-		}
-	}
-
-	@keyframes -global-swipe-out-right {
-		from {
-			transform: var(--y) translateX(var(--swipe-amount-x));
-			opacity: 1;
-		}
-
-		to {
-			transform: var(--y) translateX(calc(var(--swipe-amount-x) + 100%));
-			opacity: 0;
-		}
-	}
-
-	@keyframes -global-swipe-out-up {
-		from {
-			transform: var(--y) translateY(var(--swipe-amount-y));
-			opacity: 1;
+		html[dir='rtl'],
+		[data-sonner-toaster][dir='rtl'] {
+			--toast-icon-margin-start: 4px;
+			--toast-icon-margin-end: -3px;
+			--toast-svg-margin-start: 0px;
+			--toast-svg-margin-end: -1px;
+			--toast-button-margin-start: 0;
+			--toast-button-margin-end: auto;
+			--toast-close-button-start: unset;
+			--toast-close-button-end: 0;
+			--toast-close-button-transform: translate(35%, -35%);
 		}
 
-		to {
-			transform: var(--y) translateY(calc(var(--swipe-amount-y) - 100%));
-			opacity: 0;
-		}
-	}
-
-	@keyframes -global-swipe-out-down {
-		from {
-			transform: var(--y) translateY(var(--swipe-amount-y));
-			opacity: 1;
-		}
-
-		to {
-			transform: var(--y) translateY(calc(var(--swipe-amount-y) + 100%));
-			opacity: 0;
-		}
-	}
-
-	@media (max-width: 600px) {
 		[data-sonner-toaster] {
 			position: fixed;
-			right: var(--mobile-offset-right);
-			left: var(--mobile-offset-left);
-			width: 100%;
+			width: var(--width);
+			font-family:
+				ui-sans-serif,
+				system-ui,
+				-apple-system,
+				BlinkMacSystemFont,
+				Segoe UI,
+				Roboto,
+				Helvetica Neue,
+				Arial,
+				Noto Sans,
+				sans-serif,
+				Apple Color Emoji,
+				Segoe UI Emoji,
+				Segoe UI Symbol,
+				Noto Color Emoji;
+			--gray1: hsl(0, 0%, 99%);
+			--gray2: hsl(0, 0%, 97.3%);
+			--gray3: hsl(0, 0%, 95.1%);
+			--gray4: hsl(0, 0%, 93%);
+			--gray5: hsl(0, 0%, 90.9%);
+			--gray6: hsl(0, 0%, 88.7%);
+			--gray7: hsl(0, 0%, 85.8%);
+			--gray8: hsl(0, 0%, 78%);
+			--gray9: hsl(0, 0%, 56.1%);
+			--gray10: hsl(0, 0%, 52.3%);
+			--gray11: hsl(0, 0%, 43.5%);
+			--gray12: hsl(0, 0%, 9%);
+			--border-radius: 8px;
+			box-sizing: border-box;
+			padding: 0;
+			margin: 0;
+			list-style: none;
+			outline: none;
+			z-index: 999999999;
+			transition: transform 400ms ease;
 		}
 
-		[data-sonner-toaster][dir='rtl'] {
-			left: calc(var(--mobile-offset-left) * -1);
+		@media (hover: none) and (pointer: coarse) {
+			[data-sonner-toaster][data-lifted='true'] {
+				transform: none;
+			}
 		}
 
-		[data-sonner-toaster] [data-sonner-toast] {
-			left: 0;
-			right: 0;
-			width: calc(100% - var(--mobile-offset-left) * 2);
+		[data-sonner-toaster][data-x-position='right'] {
+			right: var(--offset-right);
 		}
 
 		[data-sonner-toaster][data-x-position='left'] {
-			left: var(--mobile-offset-left);
-		}
-
-		[data-sonner-toaster][data-y-position='bottom'] {
-			bottom: var(--mobile-offset-bottom);
-		}
-
-		[data-sonner-toaster][data-y-position='top'] {
-			top: var(--mobile-offset-top);
+			left: var(--offset-left);
 		}
 
 		[data-sonner-toaster][data-x-position='center'] {
-			left: var(--mobile-offset-left);
-			right: var(--mobile-offset-right);
-			transform: none;
+			left: 50%;
+			transform: translateX(-50%);
 		}
-	}
 
-	[data-sonner-toaster][data-sonner-theme='light'] {
-		--normal-bg: #fff;
-		--normal-border: var(--gray4);
-		--normal-text: var(--gray12);
+		[data-sonner-toaster][data-y-position='top'] {
+			top: var(--offset-top);
+		}
 
-		--success-bg: hsl(143, 85%, 96%);
-		--success-border: hsl(145, 92%, 87%);
-		--success-text: hsl(140, 100%, 27%);
+		[data-sonner-toaster][data-y-position='bottom'] {
+			bottom: var(--offset-bottom);
+		}
 
-		--info-bg: hsl(208, 100%, 97%);
-		--info-border: hsl(221, 91%, 93%);
-		--info-text: hsl(210, 92%, 45%);
+		[data-sonner-toast] {
+			--y: translateY(100%);
+			--lift-amount: calc(var(--lift) * var(--gap));
+			z-index: var(--z-index);
+			position: absolute;
+			opacity: 0;
+			transform: var(--y);
+			touch-action: none;
+			transition:
+				transform 400ms,
+				opacity 400ms,
+				height 400ms,
+				box-shadow 200ms;
+			box-sizing: border-box;
+			outline: none;
+			overflow-wrap: anywhere;
+		}
 
-		--warning-bg: hsl(49, 100%, 97%);
-		--warning-border: hsl(49, 91%, 84%);
-		--warning-text: hsl(31, 92%, 45%);
+		[data-sonner-toast][data-styled='true'] {
+			padding: 16px;
+			background: var(--normal-bg);
+			border: 1px solid var(--normal-border);
+			color: var(--normal-text);
+			border-radius: var(--border-radius);
+			box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.1);
+			width: var(--width);
+			font-size: 13px;
+			display: flex;
+			align-items: center;
+			gap: 6px;
+		}
 
-		--error-bg: hsl(359, 100%, 97%);
-		--error-border: hsl(359, 100%, 94%);
-		--error-text: hsl(360, 100%, 45%);
-	}
+		[data-sonner-toast]:focus-visible {
+			box-shadow:
+				0px 4px 12px rgba(0, 0, 0, 0.1),
+				0 0 0 2px rgba(0, 0, 0, 0.2);
+		}
 
-	[data-sonner-toaster][data-sonner-theme='light']
-		[data-sonner-toast][data-invert='true'] {
-		--normal-bg: #000;
-		--normal-border: hsl(0, 0%, 20%);
-		--normal-text: var(--gray1);
-	}
+		[data-sonner-toast][data-y-position='top'] {
+			top: 0;
+			--y: translateY(-100%);
+			--lift: 1;
+			--lift-amount: calc(1 * var(--gap));
+		}
 
-	[data-sonner-toaster][data-sonner-theme='dark']
-		[data-sonner-toast][data-invert='true'] {
-		--normal-bg: #fff;
-		--normal-border: var(--gray3);
-		--normal-text: var(--gray12);
-	}
+		[data-sonner-toast][data-y-position='bottom'] {
+			bottom: 0;
+			--y: translateY(100%);
+			--lift: -1;
+			--lift-amount: calc(var(--lift) * var(--gap));
+		}
 
-	[data-sonner-toaster][data-sonner-theme='dark'] {
-		--normal-bg: #000;
-		--normal-bg-hover: hsl(0, 0%, 12%);
-		--normal-border: hsl(0, 0%, 20%);
-		--normal-border-hover: hsl(0, 0%, 25%);
-		--normal-text: var(--gray1);
+		[data-sonner-toast][data-styled='true'] [data-description] {
+			font-weight: 400;
+			line-height: 1.4;
+			color: #3f3f3f;
+		}
 
-		--success-bg: hsl(150, 100%, 6%);
-		--success-border: hsl(147, 100%, 12%);
-		--success-text: hsl(150, 86%, 65%);
+		[data-rich-colors='true'][data-sonner-toast][data-styled='true']
+			[data-description] {
+			color: inherit;
+		}
 
-		--info-bg: hsl(215, 100%, 6%);
-		--info-border: hsl(223, 43%, 17%);
-		--info-text: hsl(216, 87%, 65%);
+		[data-sonner-toaster][data-sonner-theme='dark'] [data-description] {
+			color: hsl(0, 0%, 91%);
+		}
 
-		--warning-bg: hsl(64, 100%, 6%);
-		--warning-border: hsl(60, 100%, 9%);
-		--warning-text: hsl(46, 87%, 65%);
+		[data-sonner-toast][data-styled='true'] [data-title] {
+			font-weight: 500;
+			line-height: 1.5;
+			color: inherit;
+		}
 
-		--error-bg: hsl(358, 76%, 10%);
-		--error-border: hsl(357, 89%, 16%);
-		--error-text: hsl(358, 100%, 81%);
-	}
+		[data-sonner-toast][data-styled='true'] [data-icon] {
+			display: flex;
+			height: 16px;
+			width: 16px;
+			position: relative;
+			justify-content: flex-start;
+			align-items: center;
+			flex-shrink: 0;
+			margin-left: var(--toast-icon-margin-start);
+			margin-right: var(--toast-icon-margin-end);
+		}
 
-	[data-sonner-toaster][data-sonner-theme='dark']
-		[data-sonner-toast][data-styled='true']
-		[data-close-button] {
-		background: var(--normal-bg);
-		border-color: var(--normal-border);
-		color: var(--normal-text);
-	}
-
-	[data-sonner-toaster][data-sonner-theme='dark']
-		[data-sonner-toast][data-styled='true']
-		[data-close-button]:hover {
-		background: var(--normal-bg-hover);
-		border-color: var(--normal-border-hover);
-	}
-
-	[data-rich-colors='true'][data-sonner-toast][data-type='success'] {
-		background: var(--success-bg);
-		border-color: var(--success-border);
-		color: var(--success-text);
-	}
-
-	[data-rich-colors='true'][data-sonner-toast][data-styled='true'][data-type='success']
-		[data-close-button] {
-		background: var(--success-bg);
-		border-color: var(--success-border);
-		color: var(--success-text);
-	}
-
-	[data-rich-colors='true'][data-sonner-toast][data-type='info'] {
-		background: var(--info-bg);
-		border-color: var(--info-border);
-		color: var(--info-text);
-	}
-
-	[data-rich-colors='true'][data-sonner-toast][data-styled='true'][data-type='info']
-		[data-close-button] {
-		background: var(--info-bg);
-		border-color: var(--info-border);
-		color: var(--info-text);
-	}
-
-	[data-rich-colors='true'][data-sonner-toast][data-type='warning'] {
-		background: var(--warning-bg);
-		border-color: var(--warning-border);
-		color: var(--warning-text);
-	}
-
-	[data-rich-colors='true'][data-sonner-toast][data-styled='true'][data-type='warning']
-		[data-close-button] {
-		background: var(--warning-bg);
-		border-color: var(--warning-border);
-		color: var(--warning-text);
-	}
-
-	[data-rich-colors='true'][data-sonner-toast][data-type='error'] {
-		background: var(--error-bg);
-		border-color: var(--error-border);
-		color: var(--error-text);
-	}
-
-	[data-rich-colors='true'][data-sonner-toast][data-styled='true'][data-type='error']
-		[data-close-button] {
-		background: var(--error-bg);
-		border-color: var(--error-border);
-		color: var(--error-text);
-	}
-
-	.sonner-loading-wrapper {
-		--size: 16px;
-		height: var(--size);
-		width: var(--size);
-		position: absolute;
-		inset: 0;
-		z-index: 10;
-	}
-
-	.sonner-loading-wrapper[data-visible='false'] {
-		transform-origin: center;
-		animation: sonner-fade-out 0.2s ease forwards;
-	}
-
-	.sonner-spinner {
-		position: relative;
-		top: 50%;
-		left: 50%;
-		height: var(--size);
-		width: var(--size);
-	}
-
-	.sonner-loading-bar {
-		animation: sonner-spin 1.2s linear infinite;
-		background: var(--gray11);
-		border-radius: 6px;
-		height: 8%;
-		left: -10%;
-		position: absolute;
-		top: -3.9%;
-		width: 24%;
-	}
-
-	.sonner-loading-bar:nth-child(1) {
-		animation-delay: -1.2s;
-		transform: rotate(0.0001deg) translate(146%);
-	}
-
-	.sonner-loading-bar:nth-child(2) {
-		animation-delay: -1.1s;
-		transform: rotate(30deg) translate(146%);
-	}
-
-	.sonner-loading-bar:nth-child(3) {
-		animation-delay: -1s;
-		transform: rotate(60deg) translate(146%);
-	}
-
-	.sonner-loading-bar:nth-child(4) {
-		animation-delay: -0.9s;
-		transform: rotate(90deg) translate(146%);
-	}
-
-	.sonner-loading-bar:nth-child(5) {
-		animation-delay: -0.8s;
-		transform: rotate(120deg) translate(146%);
-	}
-
-	.sonner-loading-bar:nth-child(6) {
-		animation-delay: -0.7s;
-		transform: rotate(150deg) translate(146%);
-	}
-
-	.sonner-loading-bar:nth-child(7) {
-		animation-delay: -0.6s;
-		transform: rotate(180deg) translate(146%);
-	}
-
-	.sonner-loading-bar:nth-child(8) {
-		animation-delay: -0.5s;
-		transform: rotate(210deg) translate(146%);
-	}
-
-	.sonner-loading-bar:nth-child(9) {
-		animation-delay: -0.4s;
-		transform: rotate(240deg) translate(146%);
-	}
-
-	.sonner-loading-bar:nth-child(10) {
-		animation-delay: -0.3s;
-		transform: rotate(270deg) translate(146%);
-	}
-
-	.sonner-loading-bar:nth-child(11) {
-		animation-delay: -0.2s;
-		transform: rotate(300deg) translate(146%);
-	}
-
-	.sonner-loading-bar:nth-child(12) {
-		animation-delay: -0.1s;
-		transform: rotate(330deg) translate(146%);
-	}
-
-	@keyframes -global-sonner-fade-in {
-		0% {
+		[data-sonner-toast][data-promise='true'] [data-icon] > svg {
 			opacity: 0;
 			transform: scale(0.8);
+			transform-origin: center;
+			animation: sonner-fade-in 300ms ease forwards;
 		}
-		100% {
-			opacity: 1;
-			transform: scale(1);
-		}
-	}
 
-	@keyframes -global-sonner-fade-out {
-		0% {
-			opacity: 1;
-			transform: scale(1);
+		[data-sonner-toast][data-styled='true'] [data-icon] > * {
+			flex-shrink: 0;
 		}
-		100% {
+
+		[data-sonner-toast][data-styled='true'] [data-icon] svg {
+			margin-left: var(--toast-svg-margin-start);
+			margin-right: var(--toast-svg-margin-end);
+		}
+
+		[data-sonner-toast][data-styled='true'] [data-content] {
+			display: flex;
+			flex-direction: column;
+			gap: 2px;
+			/* Take the space the icon and the buttons leave, so a custom title or
+		   description isn't limited to the width of its text */
+			flex: 1;
+			min-width: 0;
+		}
+
+		[data-sonner-toast][data-styled='true'] [data-button] {
+			border-radius: 4px;
+			padding-left: 8px;
+			padding-right: 8px;
+			height: 24px;
+			font-size: 12px;
+			color: var(--normal-bg);
+			background: var(--normal-text);
+			margin-left: var(--toast-button-margin-start);
+			margin-right: var(--toast-button-margin-end);
+			border: none;
+			font-weight: 500;
+			cursor: pointer;
+			outline: none;
+			display: flex;
+			align-items: center;
+			flex-shrink: 0;
+			transition:
+				opacity 400ms,
+				box-shadow 200ms;
+		}
+
+		[data-sonner-toast][data-styled='true'] [data-button]:focus-visible {
+			box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.4);
+		}
+
+		[data-sonner-toast][data-styled='true'] [data-button]:first-of-type {
+			margin-left: var(--toast-button-margin-start);
+			margin-right: var(--toast-button-margin-end);
+		}
+
+		[data-sonner-toast][data-styled='true'] [data-cancel] {
+			color: var(--normal-text);
+			background: rgba(0, 0, 0, 0.08);
+		}
+
+		[data-sonner-toaster][data-sonner-theme='dark']
+			[data-sonner-toast][data-styled='true']
+			[data-cancel] {
+			background: rgba(255, 255, 255, 0.3);
+		}
+
+		[data-sonner-toast][data-styled='true'] [data-close-button] {
+			position: absolute;
+			left: var(--toast-close-button-start);
+			right: var(--toast-close-button-end);
+			top: 0;
+			height: 20px;
+			width: 20px;
+			display: flex;
+			justify-content: center;
+			align-items: center;
+			padding: 0;
+			color: var(--gray12);
+			background: var(--normal-bg);
+			border: 1px solid var(--gray4);
+			transform: var(--toast-close-button-transform);
+			border-radius: 50%;
+			cursor: pointer;
+			z-index: 1;
+			transition:
+				opacity 100ms,
+				background 200ms,
+				border-color 200ms;
+		}
+
+		[data-sonner-toast][data-styled='true']
+			[data-close-button]:focus-visible {
+			box-shadow:
+				0px 4px 12px rgba(0, 0, 0, 0.1),
+				0 0 0 2px rgba(0, 0, 0, 0.2);
+		}
+
+		[data-sonner-toast][data-styled='true'] [data-disabled='true'] {
+			cursor: not-allowed;
+		}
+
+		[data-sonner-toast][data-styled='true']:hover
+			[data-close-button]:hover {
+			background: var(--gray2);
+			border-color: var(--gray5);
+		}
+
+		[data-sonner-toast][data-swiping='true']::before {
+			content: '';
+			position: absolute;
+			left: -100%;
+			right: -100%;
+			height: 100%;
+			z-index: -1;
+		}
+
+		[data-sonner-toast][data-y-position='top'][data-swiping='true']::before {
+			bottom: 50%;
+			transform: scaleY(3) translateY(50%);
+		}
+
+		[data-sonner-toast][data-y-position='bottom'][data-swiping='true']::before {
+			top: 50%;
+			transform: scaleY(3) translateY(-50%);
+		}
+
+		[data-sonner-toast][data-swiping='false'][data-removed='true']::before {
+			content: '';
+			position: absolute;
+			inset: 0;
+			transform: scaleY(2);
+		}
+
+		[data-sonner-toast][data-expanded='true']::after {
+			content: '';
+			position: absolute;
+			left: 0;
+			height: calc(var(--gap) + 1px);
+			bottom: 100%;
+			width: 100%;
+		}
+
+		[data-sonner-toast][data-mounted='true'] {
+			--y: translateY(0);
+			opacity: 1;
+		}
+
+		[data-sonner-toast][data-expanded='false'][data-front='false'] {
+			--scale: var(--toasts-before) * 0.05 + 1;
+			--y: translateY(calc(var(--lift-amount) * var(--toasts-before)))
+				scale(calc(-1 * var(--scale)));
+			height: var(--front-toast-height);
+		}
+
+		[data-sonner-toast] > * {
+			transition: opacity 400ms;
+		}
+
+		[data-sonner-toast][data-x-position='right'] {
+			right: 0;
+		}
+
+		[data-sonner-toast][data-x-position='left'] {
+			left: 0;
+		}
+
+		[data-sonner-toast][data-expanded='false'][data-front='false'][data-styled='true']
+			> * {
 			opacity: 0;
-			transform: scale(0.8);
 		}
-	}
 
-	@keyframes -global-sonner-spin {
-		0% {
-			opacity: 1;
+		[data-sonner-toast][data-visible='false'] {
+			opacity: 0;
+			pointer-events: none;
 		}
-		100% {
-			opacity: 0.15;
-		}
-	}
 
-	@media (prefers-reduced-motion) {
-		[data-sonner-toast],
-		[data-sonner-toast] > *,
+		[data-sonner-toast][data-mounted='true'][data-expanded='true'] {
+			--y: translateY(calc(var(--lift) * var(--offset)));
+			height: var(--initial-height);
+		}
+
+		[data-sonner-toast][data-removed='true'][data-front='true'][data-swipe-out='false'] {
+			--y: translateY(calc(var(--lift) * -100%));
+			opacity: 0;
+		}
+
+		[data-sonner-toast][data-removed='true'][data-front='false'][data-swipe-out='false'][data-expanded='true'] {
+			--y: translateY(
+				calc(var(--lift) * var(--offset) + var(--lift) * -100%)
+			);
+			opacity: 0;
+		}
+
+		[data-sonner-toast][data-removed='true'][data-front='false'][data-swipe-out='false'][data-expanded='false'] {
+			--y: translateY(40%);
+			opacity: 0;
+			transition:
+				transform 500ms,
+				opacity 200ms;
+		}
+
+		[data-sonner-toast][data-removed='true'][data-front='false']::before {
+			height: calc(var(--initial-height) + 20%);
+		}
+
+		[data-sonner-toast][data-swiping='true'] {
+			transform: var(--y) translateY(var(--swipe-amount-y, 0px))
+				translateX(var(--swipe-amount-x, 0px));
+			transition: none;
+		}
+
+		[data-sonner-toast][data-swiped='true'] {
+			user-select: none;
+		}
+
+		[data-sonner-toast][data-swipe-out='true'][data-y-position='bottom'],
+		[data-sonner-toast][data-swipe-out='true'][data-y-position='top'] {
+			animation-duration: 200ms;
+			animation-timing-function: ease-out;
+			animation-fill-mode: forwards;
+		}
+
+		[data-sonner-toast][data-swipe-out='true'][data-swipe-direction='left'] {
+			animation-name: swipe-out-left;
+		}
+
+		[data-sonner-toast][data-swipe-out='true'][data-swipe-direction='right'] {
+			animation-name: swipe-out-right;
+		}
+
+		[data-sonner-toast][data-swipe-out='true'][data-swipe-direction='up'] {
+			animation-name: swipe-out-up;
+		}
+
+		[data-sonner-toast][data-swipe-out='true'][data-swipe-direction='down'] {
+			animation-name: swipe-out-down;
+		}
+
+		@keyframes -global-swipe-out-left {
+			from {
+				transform: var(--y) translateX(var(--swipe-amount-x));
+				opacity: 1;
+			}
+
+			to {
+				transform: var(--y)
+					translateX(calc(var(--swipe-amount-x) - 100%));
+				opacity: 0;
+			}
+		}
+
+		@keyframes -global-swipe-out-right {
+			from {
+				transform: var(--y) translateX(var(--swipe-amount-x));
+				opacity: 1;
+			}
+
+			to {
+				transform: var(--y)
+					translateX(calc(var(--swipe-amount-x) + 100%));
+				opacity: 0;
+			}
+		}
+
+		@keyframes -global-swipe-out-up {
+			from {
+				transform: var(--y) translateY(var(--swipe-amount-y));
+				opacity: 1;
+			}
+
+			to {
+				transform: var(--y)
+					translateY(calc(var(--swipe-amount-y) - 100%));
+				opacity: 0;
+			}
+		}
+
+		@keyframes -global-swipe-out-down {
+			from {
+				transform: var(--y) translateY(var(--swipe-amount-y));
+				opacity: 1;
+			}
+
+			to {
+				transform: var(--y)
+					translateY(calc(var(--swipe-amount-y) + 100%));
+				opacity: 0;
+			}
+		}
+
+		@media (max-width: 600px) {
+			[data-sonner-toaster] {
+				position: fixed;
+				right: var(--mobile-offset-right);
+				left: var(--mobile-offset-left);
+				width: 100%;
+			}
+
+			[data-sonner-toaster][dir='rtl'] {
+				left: calc(var(--mobile-offset-left) * -1);
+			}
+
+			[data-sonner-toaster] [data-sonner-toast] {
+				left: 0;
+				right: 0;
+				width: calc(100% - var(--mobile-offset-left) * 2);
+			}
+
+			[data-sonner-toaster][data-x-position='left'] {
+				left: var(--mobile-offset-left);
+			}
+
+			[data-sonner-toaster][data-y-position='bottom'] {
+				bottom: var(--mobile-offset-bottom);
+			}
+
+			[data-sonner-toaster][data-y-position='top'] {
+				top: var(--mobile-offset-top);
+			}
+
+			[data-sonner-toaster][data-x-position='center'] {
+				left: var(--mobile-offset-left);
+				right: var(--mobile-offset-right);
+				transform: none;
+			}
+		}
+
+		[data-sonner-toaster][data-sonner-theme='light'] {
+			--normal-bg: #fff;
+			--normal-border: var(--gray4);
+			--normal-text: var(--gray12);
+
+			--success-bg: hsl(143, 85%, 96%);
+			--success-border: hsl(145, 92%, 87%);
+			--success-text: hsl(140, 100%, 27%);
+
+			--info-bg: hsl(208, 100%, 97%);
+			--info-border: hsl(221, 91%, 93%);
+			--info-text: hsl(210, 92%, 45%);
+
+			--warning-bg: hsl(49, 100%, 97%);
+			--warning-border: hsl(49, 91%, 84%);
+			--warning-text: hsl(31, 92%, 45%);
+
+			--error-bg: hsl(359, 100%, 97%);
+			--error-border: hsl(359, 100%, 94%);
+			--error-text: hsl(360, 100%, 45%);
+		}
+
+		[data-sonner-toaster][data-sonner-theme='light']
+			[data-sonner-toast][data-invert='true'] {
+			--normal-bg: #000;
+			--normal-border: hsl(0, 0%, 20%);
+			--normal-text: var(--gray1);
+		}
+
+		[data-sonner-toaster][data-sonner-theme='dark']
+			[data-sonner-toast][data-invert='true'] {
+			--normal-bg: #fff;
+			--normal-border: var(--gray3);
+			--normal-text: var(--gray12);
+		}
+
+		[data-sonner-toaster][data-sonner-theme='dark'] {
+			--normal-bg: #000;
+			--normal-bg-hover: hsl(0, 0%, 12%);
+			--normal-border: hsl(0, 0%, 20%);
+			--normal-border-hover: hsl(0, 0%, 25%);
+			--normal-text: var(--gray1);
+
+			--success-bg: hsl(150, 100%, 6%);
+			--success-border: hsl(147, 100%, 12%);
+			--success-text: hsl(150, 86%, 65%);
+
+			--info-bg: hsl(215, 100%, 6%);
+			--info-border: hsl(223, 43%, 17%);
+			--info-text: hsl(216, 87%, 65%);
+
+			--warning-bg: hsl(64, 100%, 6%);
+			--warning-border: hsl(60, 100%, 9%);
+			--warning-text: hsl(46, 87%, 65%);
+
+			--error-bg: hsl(358, 76%, 10%);
+			--error-border: hsl(357, 89%, 16%);
+			--error-text: hsl(358, 100%, 81%);
+		}
+
+		[data-sonner-toaster][data-sonner-theme='dark']
+			[data-sonner-toast][data-styled='true']
+			[data-close-button] {
+			background: var(--normal-bg);
+			border-color: var(--normal-border);
+			color: var(--normal-text);
+		}
+
+		[data-sonner-toaster][data-sonner-theme='dark']
+			[data-sonner-toast][data-styled='true']
+			[data-close-button]:hover {
+			background: var(--normal-bg-hover);
+			border-color: var(--normal-border-hover);
+		}
+
+		[data-rich-colors='true'][data-sonner-toast][data-type='success'] {
+			background: var(--success-bg);
+			border-color: var(--success-border);
+			color: var(--success-text);
+		}
+
+		[data-rich-colors='true'][data-sonner-toast][data-styled='true'][data-type='success']
+			[data-close-button] {
+			background: var(--success-bg);
+			border-color: var(--success-border);
+			color: var(--success-text);
+		}
+
+		[data-rich-colors='true'][data-sonner-toast][data-type='info'] {
+			background: var(--info-bg);
+			border-color: var(--info-border);
+			color: var(--info-text);
+		}
+
+		[data-rich-colors='true'][data-sonner-toast][data-styled='true'][data-type='info']
+			[data-close-button] {
+			background: var(--info-bg);
+			border-color: var(--info-border);
+			color: var(--info-text);
+		}
+
+		[data-rich-colors='true'][data-sonner-toast][data-type='warning'] {
+			background: var(--warning-bg);
+			border-color: var(--warning-border);
+			color: var(--warning-text);
+		}
+
+		[data-rich-colors='true'][data-sonner-toast][data-styled='true'][data-type='warning']
+			[data-close-button] {
+			background: var(--warning-bg);
+			border-color: var(--warning-border);
+			color: var(--warning-text);
+		}
+
+		[data-rich-colors='true'][data-sonner-toast][data-type='error'] {
+			background: var(--error-bg);
+			border-color: var(--error-border);
+			color: var(--error-text);
+		}
+
+		[data-rich-colors='true'][data-sonner-toast][data-styled='true'][data-type='error']
+			[data-close-button] {
+			background: var(--error-bg);
+			border-color: var(--error-border);
+			color: var(--error-text);
+		}
+
+		.sonner-loading-wrapper {
+			--size: 16px;
+			height: var(--size);
+			width: var(--size);
+			position: absolute;
+			inset: 0;
+			z-index: 10;
+		}
+
+		.sonner-loading-wrapper[data-visible='false'] {
+			transform-origin: center;
+			animation: sonner-fade-out 0.2s ease forwards;
+		}
+
+		.sonner-spinner {
+			position: relative;
+			top: 50%;
+			left: 50%;
+			height: var(--size);
+			width: var(--size);
+		}
+
 		.sonner-loading-bar {
-			transition: none !important;
-			animation: none !important;
+			animation: sonner-spin 1.2s linear infinite;
+			background: var(--gray11);
+			border-radius: 6px;
+			height: 8%;
+			left: -10%;
+			position: absolute;
+			top: -3.9%;
+			width: 24%;
 		}
-	}
 
-	.sonner-loader {
-		position: absolute;
-		top: 50%;
-		left: 50%;
-		transform: translate(-50%, -50%);
-		transform-origin: center;
-		transition:
-			opacity 200ms,
-			transform 200ms;
-	}
+		.sonner-loading-bar:nth-child(1) {
+			animation-delay: -1.2s;
+			transform: rotate(0.0001deg) translate(146%);
+		}
 
-	.sonner-loader[data-visible='false'] {
-		opacity: 0;
-		transform: scale(0.8) translate(-50%, -50%);
-	}
+		.sonner-loading-bar:nth-child(2) {
+			animation-delay: -1.1s;
+			transform: rotate(30deg) translate(146%);
+		}
+
+		.sonner-loading-bar:nth-child(3) {
+			animation-delay: -1s;
+			transform: rotate(60deg) translate(146%);
+		}
+
+		.sonner-loading-bar:nth-child(4) {
+			animation-delay: -0.9s;
+			transform: rotate(90deg) translate(146%);
+		}
+
+		.sonner-loading-bar:nth-child(5) {
+			animation-delay: -0.8s;
+			transform: rotate(120deg) translate(146%);
+		}
+
+		.sonner-loading-bar:nth-child(6) {
+			animation-delay: -0.7s;
+			transform: rotate(150deg) translate(146%);
+		}
+
+		.sonner-loading-bar:nth-child(7) {
+			animation-delay: -0.6s;
+			transform: rotate(180deg) translate(146%);
+		}
+
+		.sonner-loading-bar:nth-child(8) {
+			animation-delay: -0.5s;
+			transform: rotate(210deg) translate(146%);
+		}
+
+		.sonner-loading-bar:nth-child(9) {
+			animation-delay: -0.4s;
+			transform: rotate(240deg) translate(146%);
+		}
+
+		.sonner-loading-bar:nth-child(10) {
+			animation-delay: -0.3s;
+			transform: rotate(270deg) translate(146%);
+		}
+
+		.sonner-loading-bar:nth-child(11) {
+			animation-delay: -0.2s;
+			transform: rotate(300deg) translate(146%);
+		}
+
+		.sonner-loading-bar:nth-child(12) {
+			animation-delay: -0.1s;
+			transform: rotate(330deg) translate(146%);
+		}
+
+		@keyframes -global-sonner-fade-in {
+			0% {
+				opacity: 0;
+				transform: scale(0.8);
+			}
+			100% {
+				opacity: 1;
+				transform: scale(1);
+			}
+		}
+
+		@keyframes -global-sonner-fade-out {
+			0% {
+				opacity: 1;
+				transform: scale(1);
+			}
+			100% {
+				opacity: 0;
+				transform: scale(0.8);
+			}
+		}
+
+		@keyframes -global-sonner-spin {
+			0% {
+				opacity: 1;
+			}
+			100% {
+				opacity: 0.15;
+			}
+		}
+
+		@media (prefers-reduced-motion) {
+			[data-sonner-toast],
+			[data-sonner-toast] > *,
+			.sonner-loading-bar {
+				transition: none !important;
+				animation: none !important;
+			}
+		}
+
+		.sonner-loader {
+			position: absolute;
+			top: 50%;
+			left: 50%;
+			transform: translate(-50%, -50%);
+			transform-origin: center;
+			transition:
+				opacity 200ms,
+				transform 200ms;
+		}
+
+		.sonner-loader[data-visible='false'] {
+			opacity: 0;
+			transform: scale(0.8) translate(-50%, -50%);
+		}
 	}
 </style>

--- a/src/lib/icons/CloseIcon.svelte
+++ b/src/lib/icons/CloseIcon.svelte
@@ -1,4 +1,5 @@
 <svg
+	aria-hidden="true"
 	xmlns="http://www.w3.org/2000/svg"
 	width="12"
 	height="12"

--- a/src/lib/icons/ErrorIcon.svelte
+++ b/src/lib/icons/ErrorIcon.svelte
@@ -1,4 +1,5 @@
 <svg
+	aria-hidden="true"
 	xmlns="http://www.w3.org/2000/svg"
 	viewBox="0 0 20 20"
 	fill="currentColor"

--- a/src/lib/icons/InfoIcon.svelte
+++ b/src/lib/icons/InfoIcon.svelte
@@ -1,4 +1,5 @@
 <svg
+	aria-hidden="true"
 	xmlns="http://www.w3.org/2000/svg"
 	viewBox="0 0 20 20"
 	fill="currentColor"

--- a/src/lib/icons/SuccessIcon.svelte
+++ b/src/lib/icons/SuccessIcon.svelte
@@ -1,4 +1,5 @@
 <svg
+	aria-hidden="true"
 	xmlns="http://www.w3.org/2000/svg"
 	viewBox="0 0 20 20"
 	fill="currentColor"

--- a/src/lib/icons/WarningIcon.svelte
+++ b/src/lib/icons/WarningIcon.svelte
@@ -1,4 +1,5 @@
 <svg
+	aria-hidden="true"
 	viewBox="0 0 64 64"
 	fill="currentColor"
 	height="20"

--- a/src/lib/toast-state.svelte.ts
+++ b/src/lib/toast-state.svelte.ts
@@ -292,7 +292,9 @@ class ToastState {
 		untrack(() => {
 			const heightIdx = this.#findHeightIdx(data.toastId);
 			if (heightIdx === -1) {
-				this.heights.push(data);
+				// Newest first: the offset math and --front-toast-height assume the
+				// front (most recent) toast's height entry is at the lowest index.
+				this.heights.unshift(data);
 			} else {
 				this.heights[heightIdx] = data;
 			}

--- a/src/lib/toast-state.svelte.ts
+++ b/src/lib/toast-state.svelte.ts
@@ -33,6 +33,8 @@ type UpdateToastProps = {
 class ToastState {
 	toasts = $state<ToastT[]>([]);
 	heights = $state<HeightT[]>([]);
+	// Removals whose exit animation is running but whose entry hasn't been removed yet
+	#pendingRemovals = new Map<number | string, ReturnType<typeof setTimeout>>();
 
 	#findToastIdx = (id: number | string): number | null => {
 		const idx = this.toasts.findIndex((toast) => toast.id === id);
@@ -58,8 +60,44 @@ class ToastState {
 			id,
 			title: message,
 			type,
+			// A dismissal that hasn't been processed yet gets cancelled: the toast is
+			// still on screen, so this is an update of it rather than a new toast.
+			dismiss: false,
+			delete: false,
 			updated: true
 		};
+	};
+
+	// Flags a toast that was dismissed from inside the Toast component (close button,
+	// swipe, action/cancel click, auto-close) so `create` treats an id reuse as a new
+	// toast instead of merging the old props into it.
+	markDismissed = (id: number | string): void => {
+		const toastIdx = this.#findToastIdx(id);
+		if (toastIdx === null) return;
+		const toast = this.toasts[toastIdx];
+		if (!toast) return;
+		if (!toast.dismiss || !toast.delete) {
+			this.toasts[toastIdx] = { ...toast, dismiss: true, delete: true };
+		}
+	};
+
+	scheduleRemoval = (id: number | string, delay: number): void => {
+		this.cancelRemoval(id);
+		this.#pendingRemovals.set(
+			id,
+			setTimeout(() => {
+				this.#pendingRemovals.delete(id);
+				this.remove(id);
+			}, delay)
+		);
+	};
+
+	cancelRemoval = (id: number | string): void => {
+		const timeout = this.#pendingRemovals.get(id);
+		if (timeout !== undefined) {
+			clearTimeout(timeout);
+			this.#pendingRemovals.delete(id);
+		}
 	};
 
 	create = <T extends AnyComponent>(
@@ -82,9 +120,19 @@ class ToastState {
 		const type = data.type === undefined ? 'default' : data.type;
 
 		untrack(() => {
+			// A removal that hasn't run yet gets cancelled: this create() supersedes it,
+			// otherwise the old toast's unmount timeout would remove the new one.
+			this.cancelRemoval(id);
+
 			const alreadyExists = this.toasts.find((toast) => toast.id === id);
 
-			if (alreadyExists) {
+			if (alreadyExists?.dismiss || alreadyExists?.delete) {
+				// The previous toast with this id was dismissed, so this is a brand new
+				// toast. Drop the old one instead of merging into it, otherwise its
+				// props (e.g. `action`) leak into the new one.
+				this.remove(id);
+				this.addToast({ ...rest, id, title: message, dismissible, type });
+			} else if (alreadyExists) {
 				this.updateToast({ id, data, type, message, dismissible });
 			} else {
 				this.addToast({ ...rest, id, title: message, dismissible, type });
@@ -97,8 +145,10 @@ class ToastState {
 	dismiss = (id?: number | string): string | number | undefined => {
 		untrack(() => {
 			if (id === undefined) {
-				// we're dismissing all the toasts
-				this.toasts = this.toasts.map((toast) => ({ ...toast, dismiss: true }));
+				// we're dismissing all the active toasts
+				this.toasts = this.toasts.map((toast) =>
+					toast.dismiss ? toast : { ...toast, dismiss: true }
+				);
 				return;
 			}
 			// we're dismissing a specific toast
@@ -252,6 +302,8 @@ class ToastState {
 	reset = () => {
 		this.toasts = [];
 		this.heights = [];
+		this.#pendingRemovals.forEach((timeout) => clearTimeout(timeout));
+		this.#pendingRemovals.clear();
 	};
 }
 

--- a/src/lib/toast-state.svelte.ts
+++ b/src/lib/toast-state.svelte.ts
@@ -16,8 +16,7 @@ let toastsCounter = 0;
 // A toast keeps the id it was given, otherwise it gets the next one from the counter.
 // `custom` needs the same id `create` would pick, as it hands it to the component.
 function getToastId(data?: { id?: number | string }): number | string {
-	return typeof data?.id === 'number' ||
-		(typeof data?.id === 'string' && data.id.length > 0)
+	return typeof data?.id === 'number' || (typeof data?.id === 'string' && data.id.length > 0)
 		? data.id
 		: toastsCounter++;
 }

--- a/src/lib/toast-state.svelte.ts
+++ b/src/lib/toast-state.svelte.ts
@@ -13,6 +13,15 @@ import { untrack } from 'svelte';
 
 let toastsCounter = 0;
 
+// A toast keeps the id it was given, otherwise it gets the next one from the counter.
+// `custom` needs the same id `create` would pick, as it hands it to the component.
+function getToastId(data?: { id?: number | string }): number | string {
+	return typeof data?.id === 'number' ||
+		(typeof data?.id === 'string' && data.id.length > 0)
+		? data.id
+		: toastsCounter++;
+}
+
 type UpdateToastProps = {
 	id: number | string;
 	data: Partial<ToastT>;
@@ -61,10 +70,7 @@ class ToastState {
 		}
 	): string | number => {
 		const { message, ...rest } = data;
-		const id =
-			typeof data?.id === 'number' || (data.id && data.id?.length > 0)
-				? data.id
-				: toastsCounter++;
+		const id = getToastId(data);
 
 		// Support deprecated `dismissable` as a fallback for backwards compatibility
 		const dismissible =
@@ -219,9 +225,9 @@ class ToastState {
 	};
 
 	custom = <T extends AnyComponent>(component: T, data?: ExternalToast<T>): string | number => {
-		const id = data?.id || toastsCounter++;
+		const id = getToastId(data);
 
-		this.create({ component, id, ...data });
+		this.create({ component, ...data, id });
 
 		return id;
 	};
@@ -259,10 +265,7 @@ function constructPromiseErrorMessage(response: unknown) {
 export const toastState = new ToastState();
 
 function toastFunction<T extends AnyComponent>(message: string | T, data?: ExternalToast<T>) {
-	return toastState.create({
-		message,
-		...data
-	});
+	return toastState.message(message, data);
 }
 
 export class SonnerState {

--- a/src/lib/toast-state.svelte.ts
+++ b/src/lib/toast-state.svelte.ts
@@ -128,9 +128,20 @@ class ToastState {
 			if (alreadyExists?.dismiss || alreadyExists?.delete) {
 				// The previous toast with this id was dismissed, so this is a brand new
 				// toast. Drop the old one instead of merging into it, otherwise its
-				// props (e.g. `action`) leak into the new one.
+				// props (e.g. `action`) leak into the new one. `updated` makes the still
+				// mounted component reset its auto-close timer: when the recreate happens
+				// in the same tick as the dismissal, the keyed each reuses the component
+				// before it ever processed the dismissal, so the old timer would
+				// otherwise keep running.
 				this.remove(id);
-				this.addToast({ ...rest, id, title: message, dismissible, type });
+				this.addToast({
+					...rest,
+					id,
+					title: message,
+					dismissible,
+					type,
+					updated: true
+				});
 			} else if (alreadyExists) {
 				this.updateToast({ id, data, type, message, dismissible });
 			} else {
@@ -290,12 +301,25 @@ class ToastState {
 		// would re-trigger it on the write below (effect_update_depth_exceeded).
 		untrack(() => {
 			const heightIdx = this.#findHeightIdx(data.toastId);
-			if (heightIdx === -1) {
-				// Newest first: the offset math and --front-toast-height assume the
-				// front (most recent) toast's height entry is at the lowest index.
-				this.heights.unshift(data);
-			} else {
+			if (heightIdx !== -1) {
 				this.heights[heightIdx] = data;
+				return;
+			}
+
+			// The offset math and --front-toast-height assume heights share the
+			// newest-first order of `toasts`, so insert at the matching position.
+			// With batched mounts (several toasts created in one tick, or created
+			// before the Toaster mounted) the components mount newest-first and a
+			// plain unshift would reverse them.
+			const order = new Map(this.toasts.map((toast, idx) => [toast.id, idx]));
+			const toastOrder = order.get(data.toastId) ?? -1;
+			const insertIdx = this.heights.findIndex(
+				(height) => (order.get(height.toastId) ?? Infinity) > toastOrder
+			);
+			if (insertIdx === -1) {
+				this.heights.push(data);
+			} else {
+				this.heights.splice(insertIdx, 0, data);
 			}
 		});
 	};

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -84,6 +84,11 @@ export type ToastT<T extends AnyComponent = AnyComponent> = {
 	classes?: ToastClasses;
 	descriptionClass?: string;
 	position?: Position;
+	/**
+	 * The id of the `<Toaster />` this toast should be rendered in. Toasts without
+	 * a `toasterId` render in the toaster without an `id`.
+	 */
+	toasterId?: string;
 	dismiss?: boolean;
 	/**
 	 * @internal This is used to determine if the toast has been updated to determine when to reset timer. Hacky but works.
@@ -102,6 +107,8 @@ export type Position =
 export type HeightT = {
 	height: number;
 	toastId: number | string;
+	toasterId?: string;
+	position?: Position;
 };
 
 export type Theme = 'light' | 'dark';
@@ -169,6 +176,12 @@ type ToastIcons = {
 };
 
 export type ToasterProps = {
+	/**
+	 * Identifies this toaster so toasts can target it via `toast(..., { toasterId })`.
+	 * A toaster without an `id` renders only the toasts without a `toasterId`.
+	 */
+	id?: string;
+
 	/**
 	 * Dark toasts in light mode and vice versa.
 	 *
@@ -382,6 +395,7 @@ export type ToastProps = {
 	toast: ToastT;
 	index: number;
 	swipeDirections?: SwipeDirection[];
+	gap?: number;
 	expanded: boolean;
 	invert: boolean;
 	position: Position;

--- a/src/routes/test/+page.svelte
+++ b/src/routes/test/+page.svelte
@@ -1,0 +1,93 @@
+<script lang="ts">
+	import { page } from '$app/state';
+	import { Toaster, toast } from '$lib/index.js';
+	import type { Position, SwipeDirection } from '$lib/types.js';
+	import CustomIcon from './CustomIcon.svelte';
+	import WideDescription from './WideDescription.svelte';
+
+	const params = page.url.searchParams;
+	const position = (params.get('position') ?? 'bottom-right') as Position;
+	const gap = params.has('gap') ? Number(params.get('gap')) : undefined;
+	const swipeDirections = params.get('swipeDirections')?.split(',') as
+		| SwipeDirection[]
+		| undefined;
+	const secondToaster = params.has('secondToaster');
+
+	// Runs during component init, before the <Toaster /> below has mounted
+	if (params.has('toastOnMount')) {
+		toast('Toast rendered on mount');
+	}
+
+	function promiseWithCustomIcon() {
+		toast.promise(new Promise((resolve) => setTimeout(resolve, 200)), {
+			loading: 'Loading...',
+			success: 'Loaded',
+			icon: CustomIcon
+		});
+	}
+
+	function dismissAndRecreate() {
+		const id = toast('Original toast');
+		toast.dismiss(id);
+		// recreate while the exit-animation removal is still pending
+		setTimeout(() => toast('Remounted toast', { id }), 100);
+	}
+</script>
+
+<Toaster
+	{position}
+	{gap}
+	{swipeDirections}
+	toastOptions={{
+		classes: {
+			default: 'default-toast-classname',
+			success: 'success-toast-classname'
+		}
+	}}
+/>
+
+{#if secondToaster}
+	<Toaster id="secondary" position="top-left" />
+{/if}
+
+<main>
+	<button
+		data-testid="default-button"
+		onclick={() => toast('My default toast')}
+	>
+		Default
+	</button>
+	<button
+		data-testid="success"
+		onclick={() => toast.success('My success toast')}
+	>
+		Success
+	</button>
+	<button data-testid="promise-custom-icon" onclick={promiseWithCustomIcon}>
+		Promise with custom icon
+	</button>
+	<button data-testid="dismiss-and-recreate" onclick={dismissAndRecreate}>
+		Dismiss and recreate
+	</button>
+	<button
+		data-testid="component-description"
+		onclick={() => toast('Custom title', { description: WideDescription })}
+	>
+		Wide description
+	</button>
+	<button
+		data-testid="action"
+		onclick={() =>
+			toast('My message', {
+				action: { label: 'Action', onClick: () => {} }
+			})}
+	>
+		Action
+	</button>
+	<button
+		data-testid="toast-to-secondary"
+		onclick={() => toast('Secondary toast', { toasterId: 'secondary' })}
+	>
+		To secondary toaster
+	</button>
+</main>

--- a/src/routes/test/+page.ts
+++ b/src/routes/test/+page.ts
@@ -1,0 +1,4 @@
+// Client-only so query params drive the page and `toast()` calls made during
+// component init exercise the real pre-mount path in the browser.
+export const ssr = false;
+export const prerender = false;

--- a/src/routes/test/+page.ts
+++ b/src/routes/test/+page.ts
@@ -1,4 +1,3 @@
 // Client-only so query params drive the page and `toast()` calls made during
 // component init exercise the real pre-mount path in the browser.
 export const ssr = false;
-export const prerender = false;

--- a/src/routes/test/CustomIcon.svelte
+++ b/src/routes/test/CustomIcon.svelte
@@ -1,0 +1,8 @@
+<svg
+	data-testid="custom-success-icon"
+	viewBox="0 0 20 20"
+	width="20"
+	height="20"
+>
+	<circle cx="10" cy="10" r="8" fill="currentColor" />
+</svg>

--- a/src/routes/test/WideDescription.svelte
+++ b/src/routes/test/WideDescription.svelte
@@ -1,0 +1,1 @@
+<div data-testid="wide-description">Short text</div>

--- a/src/tests/MultiToasterTest.svelte
+++ b/src/tests/MultiToasterTest.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+	import { Toaster, toast } from '$lib/index.js';
+	const { cb }: { cb: (t: typeof toast) => void } = $props();
+
+	function onClick() {
+		cb(toast);
+	}
+</script>
+
+<div data-testid="default-toaster">
+	<Toaster />
+</div>
+
+<div data-testid="named-toaster">
+	<Toaster id="secondary" position="top-center" />
+</div>
+
+<button data-testid="trigger" onclick={onClick}>Trigger</button>

--- a/src/tests/PropsToastTest.svelte
+++ b/src/tests/PropsToastTest.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { Toaster, toast } from '$lib/index.js';
+	import type { ToasterProps } from '$lib/index.js';
+
+	const {
+		cb,
+		...toasterProps
+	}: { cb: (t: typeof toast) => void } & ToasterProps = $props();
+
+	function onClick() {
+		cb(toast);
+	}
+</script>
+
+<Toaster {...toasterProps} />
+
+<button data-testid="trigger" onclick={onClick}>Trigger</button>

--- a/src/tests/TestIcon.svelte
+++ b/src/tests/TestIcon.svelte
@@ -1,0 +1,3 @@
+<svg data-testid="custom-icon" viewBox="0 0 20 20" width="20" height="20">
+	<circle cx="10" cy="10" r="8" />
+</svg>

--- a/src/tests/toast-lifecycle.spec.ts
+++ b/src/tests/toast-lifecycle.spec.ts
@@ -1,6 +1,5 @@
 import { describe, it } from 'vitest';
 import PropsToastTest from './PropsToastTest.svelte';
-import MultiToasterTest from './MultiToasterTest.svelte';
 import TestIcon from './TestIcon.svelte';
 import { render, waitFor } from '@testing-library/svelte';
 import { userEvent } from '@testing-library/user-event';
@@ -20,34 +19,9 @@ function setup(props: { cb: (t: typeof toast) => void } & ToasterProps) {
 	};
 }
 
-// Ports of the fixes batched in emilkowalski/sonner#777
-describe('upstream sonner#777 parity', () => {
+describe('Toast lifecycle', () => {
 	beforeEach(() => {
 		toastState.reset();
-	});
-
-	it('applies classes.default only to toasts without a type', async () => {
-		const { user, trigger, container } = setup({
-			cb: (toast) => {
-				toast('Plain toast');
-				toast.success('Success toast');
-			},
-			toastOptions: {
-				classes: {
-					default: 'default-toast-class',
-					success: 'success-toast-class'
-				}
-			}
-		});
-
-		await user.click(trigger);
-
-		const plain = container.querySelector('[data-sonner-toast][data-type="default"]');
-		const success = container.querySelector('[data-sonner-toast][data-type="success"]');
-
-		expect(plain).toHaveClass('default-toast-class');
-		expect(success).toHaveClass('success-toast-class');
-		expect(success).not.toHaveClass('default-toast-class');
 	});
 
 	it('renders a custom icon only once in a settled promise toast', async () => {
@@ -131,14 +105,6 @@ describe('upstream sonner#777 parity', () => {
 		);
 	});
 
-	it('shows a toast created before the Toaster mounts', async () => {
-		toast('Created before mount');
-
-		const { getByText } = setup({ cb: () => {} });
-
-		await waitFor(() => expect(getByText('Created before mount')).toBeVisible());
-	});
-
 	it('does not leak props into a new toast reusing a dismissed toast id', async () => {
 		const { user, trigger, getByText, queryByText } = setup({
 			cb: (toast) => {
@@ -208,77 +174,5 @@ describe('upstream sonner#777 parity', () => {
 		await user.click(trigger);
 		expect(returnedId).toBe(0);
 		expect(toastState.toasts[0]?.id).toBe(0);
-	});
-
-	it('routes toasts to the toaster matching their toasterId', async () => {
-		const user = userEvent.setup();
-		const { getByTestId } = render(MultiToasterTest, {
-			props: {
-				cb: (toast: typeof import('$lib/toast-state.svelte.js').toast) => {
-					toast('For the default toaster');
-					toast('For the named toaster', { toasterId: 'secondary' });
-				}
-			}
-		});
-
-		await user.click(getByTestId('trigger'));
-
-		const defaultToaster = getByTestId('default-toaster');
-		const namedToaster = getByTestId('named-toaster');
-
-		expect(defaultToaster).toHaveTextContent('For the default toaster');
-		expect(defaultToaster).not.toHaveTextContent('For the named toaster');
-		expect(namedToaster).toHaveTextContent('For the named toaster');
-		expect(namedToaster).not.toHaveTextContent('For the default toaster');
-	});
-
-	it('dismisses toasts across all toasters with toast.dismiss()', async () => {
-		const user = userEvent.setup();
-		const { getByTestId } = render(MultiToasterTest, {
-			props: {
-				cb: (toast: typeof import('$lib/toast-state.svelte.js').toast) => {
-					toast('Default toast');
-					toast('Named toast', { toasterId: 'secondary' });
-					setTimeout(() => toast.dismiss(), 100);
-				}
-			}
-		});
-
-		await user.click(getByTestId('trigger'));
-		expect(getByTestId('default-toaster')).toHaveTextContent('Default toast');
-
-		await sleep(500);
-		expect(
-			document.querySelectorAll('[data-sonner-toast]:not([data-removed="true"])').length
-		).toBe(0);
-	});
-
-	it('uses the gap prop in the offset math', async () => {
-		const { user, trigger, container } = setup({
-			cb: (toast) => {
-				toast('First toast');
-				toast('Second toast');
-			},
-			gap: 20
-		});
-
-		await user.click(trigger);
-
-		const offsets = Array.from(
-			container.querySelectorAll<HTMLElement>('[data-sonner-toast]')
-		).map((el) => el.style.getPropertyValue('--offset'));
-
-		// jsdom measures zero heights, so the non-front toast's offset is exactly the gap
-		expect(offsets).toContain('20px');
-	});
-
-	it('shows the close button when set via toastOptions', async () => {
-		const { user, trigger, container } = setup({
-			cb: (toast) => toast('With close button'),
-			toastOptions: { closeButton: true }
-		});
-
-		await user.click(trigger);
-		expect(container.querySelector('[data-close-button]')).not.toBeNull();
 	});
 });

--- a/src/tests/toast-lifecycle.spec.ts
+++ b/src/tests/toast-lifecycle.spec.ts
@@ -137,6 +137,28 @@ describe('Toast lifecycle', () => {
 		expect(document.querySelector('[data-sonner-toast][data-removed="true"]')).toBeNull();
 	});
 
+	it('resets the auto-close timer when a dismissed id is recreated in the same tick', async () => {
+		const { user, trigger, getByText, queryByText } = setup({
+			cb: (toast) => {
+				const id = toast('Short toast', { duration: 100 });
+				setTimeout(() => {
+					toast.dismiss(id);
+					toast('Longer toast', { id, duration: 600 });
+				}, 50);
+			}
+		});
+
+		await user.click(trigger);
+
+		// The short toast's 100ms timer would remove the replacement at ~150ms
+		// if the recreate didn't reset it
+		await sleep(400);
+		expect(getByText('Longer toast')).toBeVisible();
+
+		// The replacement's own 600ms duration still applies
+		await waitFor(() => expect(queryByText('Longer toast')).toBeNull());
+	});
+
 	it('treats an id reused after a close-button dismissal as a new toast', async () => {
 		let onDismissCalls = 0;
 		let toastId: string | number;

--- a/src/tests/toast.spec.ts
+++ b/src/tests/toast.spec.ts
@@ -42,10 +42,10 @@ describe('Toast', () => {
 		expect(queryByText('Hello world')).toBeNull();
 
 		await user.click(trigger);
-		waitFor(() => expect(queryByText('Hello world')).not.toBeNull());
+		await waitFor(() => expect(queryByText('Hello world')).not.toBeNull());
 
-		await sleep(500);
-		expect(queryByText('Hello world')).toBeNull();
+		// duration (300ms) + exit animation (200ms), with margin for slow runs
+		await waitFor(() => expect(queryByText('Hello world')).toBeNull());
 	});
 
 	it('should focus the toast when hotkey is pressed', async () => {

--- a/src/tests/toaster.spec.ts
+++ b/src/tests/toaster.spec.ts
@@ -1,0 +1,130 @@
+import { describe, it } from 'vitest';
+import PropsToastTest from './PropsToastTest.svelte';
+import MultiToasterTest from './MultiToasterTest.svelte';
+import { render, waitFor } from '@testing-library/svelte';
+import { userEvent } from '@testing-library/user-event';
+import { toast, toastState } from '$lib/toast-state.svelte.js';
+import { sleep } from './utils.js';
+import type { ToasterProps } from '$lib/index.js';
+
+function setup(props: { cb: (t: typeof toast) => void } & ToasterProps) {
+	const user = userEvent.setup();
+	const returned = render(PropsToastTest, { props });
+	const trigger = returned.getByTestId('trigger');
+
+	return {
+		trigger,
+		user,
+		...returned
+	};
+}
+
+describe('Toaster', () => {
+	beforeEach(() => {
+		toastState.reset();
+	});
+
+	it('applies classes.default only to toasts without a type', async () => {
+		const { user, trigger, container } = setup({
+			cb: (toast) => {
+				toast('Plain toast');
+				toast.success('Success toast');
+			},
+			toastOptions: {
+				classes: {
+					default: 'default-toast-class',
+					success: 'success-toast-class'
+				}
+			}
+		});
+
+		await user.click(trigger);
+
+		const plain = container.querySelector('[data-sonner-toast][data-type="default"]');
+		const success = container.querySelector('[data-sonner-toast][data-type="success"]');
+
+		expect(plain).toHaveClass('default-toast-class');
+		expect(success).toHaveClass('success-toast-class');
+		expect(success).not.toHaveClass('default-toast-class');
+	});
+
+	it('shows a toast created before the Toaster mounts', async () => {
+		toast('Created before mount');
+
+		const { getByText } = setup({ cb: () => {} });
+
+		await waitFor(() => expect(getByText('Created before mount')).toBeVisible());
+	});
+
+	it('routes toasts to the toaster matching their toasterId', async () => {
+		const user = userEvent.setup();
+		const { getByTestId } = render(MultiToasterTest, {
+			props: {
+				cb: (toast: typeof import('$lib/toast-state.svelte.js').toast) => {
+					toast('For the default toaster');
+					toast('For the named toaster', { toasterId: 'secondary' });
+				}
+			}
+		});
+
+		await user.click(getByTestId('trigger'));
+
+		const defaultToaster = getByTestId('default-toaster');
+		const namedToaster = getByTestId('named-toaster');
+
+		expect(defaultToaster).toHaveTextContent('For the default toaster');
+		expect(defaultToaster).not.toHaveTextContent('For the named toaster');
+		expect(namedToaster).toHaveTextContent('For the named toaster');
+		expect(namedToaster).not.toHaveTextContent('For the default toaster');
+	});
+
+	it('dismisses toasts across all toasters with toast.dismiss()', async () => {
+		const user = userEvent.setup();
+		const { getByTestId } = render(MultiToasterTest, {
+			props: {
+				cb: (toast: typeof import('$lib/toast-state.svelte.js').toast) => {
+					toast('Default toast');
+					toast('Named toast', { toasterId: 'secondary' });
+					setTimeout(() => toast.dismiss(), 100);
+				}
+			}
+		});
+
+		await user.click(getByTestId('trigger'));
+		expect(getByTestId('default-toaster')).toHaveTextContent('Default toast');
+
+		await sleep(500);
+		expect(
+			document.querySelectorAll('[data-sonner-toast]:not([data-removed="true"])').length
+		).toBe(0);
+	});
+
+	it('uses the gap prop in the offset math', async () => {
+		const { user, trigger, container } = setup({
+			cb: (toast) => {
+				toast('First toast');
+				toast('Second toast');
+			},
+			gap: 20
+		});
+
+		await user.click(trigger);
+
+		const offsets = Array.from(
+			container.querySelectorAll<HTMLElement>('[data-sonner-toast]')
+		).map((el) => el.style.getPropertyValue('--offset'));
+
+		// jsdom measures zero heights, so the non-front toast's offset is exactly the gap
+		expect(offsets).toContain('20px');
+	});
+
+	it('shows the close button when set via toastOptions', async () => {
+		const { user, trigger, container } = setup({
+			cb: (toast) => toast('With close button'),
+			toastOptions: { closeButton: true }
+		});
+
+		await user.click(trigger);
+		expect(container.querySelector('[data-close-button]')).not.toBeNull();
+	});
+});

--- a/src/tests/toaster.spec.ts
+++ b/src/tests/toaster.spec.ts
@@ -60,7 +60,7 @@ describe('Toaster', () => {
 		const user = userEvent.setup();
 		const { getByTestId } = render(MultiToasterTest, {
 			props: {
-				cb: (toast: typeof import('$lib/toast-state.svelte.js').toast) => {
+				cb: () => {
 					toast('For the default toaster');
 					toast('For the named toaster', { toasterId: 'secondary' });
 				}
@@ -82,7 +82,7 @@ describe('Toaster', () => {
 		const user = userEvent.setup();
 		const { getByTestId } = render(MultiToasterTest, {
 			props: {
-				cb: (toast: typeof import('$lib/toast-state.svelte.js').toast) => {
+				cb: () => {
 					toast('Default toast');
 					toast('Named toast', { toasterId: 'secondary' });
 					setTimeout(() => toast.dismiss(), 100);

--- a/src/tests/toaster.spec.ts
+++ b/src/tests/toaster.spec.ts
@@ -99,6 +99,22 @@ describe('Toaster', () => {
 		).toBe(0);
 	});
 
+	it('registers heights newest-first when toasts mount in the same tick', async () => {
+		let olderId: string | number;
+		let newerId: string | number;
+		const { user, trigger } = setup({
+			cb: (toast) => {
+				olderId = toast('Older toast');
+				newerId = toast('Newer toast');
+			}
+		});
+
+		await user.click(trigger);
+
+		await waitFor(() => expect(toastState.heights.length).toBe(2));
+		expect(toastState.heights.map((height) => height.toastId)).toEqual([newerId!, olderId!]);
+	});
+
 	it('uses the gap prop in the offset math', async () => {
 		const { user, trigger, container } = setup({
 			cb: (toast) => {

--- a/src/tests/upstream-sync.spec.ts
+++ b/src/tests/upstream-sync.spec.ts
@@ -1,0 +1,145 @@
+import { describe, it } from 'vitest';
+import PropsToastTest from './PropsToastTest.svelte';
+import TestIcon from './TestIcon.svelte';
+import { render, waitFor } from '@testing-library/svelte';
+import { userEvent } from '@testing-library/user-event';
+import { toast, toastState } from '$lib/toast-state.svelte.js';
+import { sleep } from './utils.js';
+import type { ToasterProps } from '$lib/index.js';
+
+function setup(props: { cb: (t: typeof toast) => void } & ToasterProps) {
+	const user = userEvent.setup();
+	const returned = render(PropsToastTest, { props });
+	const trigger = returned.getByTestId('trigger');
+
+	return {
+		trigger,
+		user,
+		...returned
+	};
+}
+
+// Ports of the fixes batched in emilkowalski/sonner#777
+describe('upstream sonner#777 parity', () => {
+	beforeEach(() => {
+		toastState.reset();
+	});
+
+	it('applies classes.default only to toasts without a type', async () => {
+		const { user, trigger, container } = setup({
+			cb: (toast) => {
+				toast('Plain toast');
+				toast.success('Success toast');
+			},
+			toastOptions: {
+				classes: {
+					default: 'default-toast-class',
+					success: 'success-toast-class'
+				}
+			}
+		});
+
+		await user.click(trigger);
+
+		const plain = container.querySelector('[data-sonner-toast][data-type="default"]');
+		const success = container.querySelector('[data-sonner-toast][data-type="success"]');
+
+		expect(plain).toHaveClass('default-toast-class');
+		expect(success).toHaveClass('success-toast-class');
+		expect(success).not.toHaveClass('default-toast-class');
+	});
+
+	it('renders a custom icon only once in a settled promise toast', async () => {
+		let resolve: (value: string) => void;
+		const promise = new Promise<string>((res) => {
+			resolve = res;
+		});
+
+		const { user, trigger, getAllByTestId, getByText } = setup({
+			cb: (toast) => {
+				toast.promise(promise, {
+					loading: 'Loading...',
+					success: 'Loaded',
+					icon: TestIcon
+				});
+			}
+		});
+
+		await user.click(trigger);
+		expect(getByText('Loading...')).toBeVisible();
+
+		resolve!('done');
+		await waitFor(() => expect(getByText('Loaded')).toBeVisible());
+		expect(getAllByTestId('custom-icon').length).toBe(1);
+	});
+
+	it('hides default icons from assistive technology', async () => {
+		const { user, trigger, container } = setup({
+			cb: (toast) => toast.success('Success toast', { closeButton: true })
+		});
+
+		await user.click(trigger);
+
+		const typeIcon = container.querySelector('[data-sonner-toast] [data-icon] svg');
+		expect(typeIcon).toHaveAttribute('aria-hidden', 'true');
+
+		const closeIcon = container.querySelector('[data-sonner-toast] [data-close-button] svg');
+		expect(closeIcon).toHaveAttribute('aria-hidden', 'true');
+	});
+
+	it('clears the loading state when toast() reuses the id of a loading toast', async () => {
+		const { user, trigger, container, getByText } = setup({
+			cb: (toast) => {
+				const id = toast.loading('Loading forever');
+				setTimeout(() => toast('Done', { id }), 100);
+			}
+		});
+
+		await user.click(trigger);
+		expect(container.querySelector('[data-sonner-toast]')).toHaveAttribute(
+			'data-type',
+			'loading'
+		);
+
+		await sleep(200);
+		expect(getByText('Done')).toBeVisible();
+		expect(container.querySelector('[data-sonner-toast]')).toHaveAttribute(
+			'data-type',
+			'default'
+		);
+	});
+
+	it('clears the loading state when toast.custom() reuses the id of a loading toast', async () => {
+		const { user, trigger, container } = setup({
+			cb: (toast) => {
+				const id = toast.loading('Loading forever');
+				setTimeout(() => toast.custom(TestIcon, { id }), 100);
+			}
+		});
+
+		await user.click(trigger);
+		expect(container.querySelector('[data-sonner-toast]')).toHaveAttribute(
+			'data-type',
+			'loading'
+		);
+
+		await sleep(200);
+		expect(container.querySelector('[data-sonner-toast]')).not.toHaveAttribute(
+			'data-type',
+			'loading'
+		);
+	});
+
+	it('keeps an explicit id of 0 in toast.custom()', async () => {
+		let returnedId: string | number | undefined;
+		const { user, trigger } = setup({
+			cb: (toast) => {
+				returnedId = toast.custom(TestIcon, { id: 0 });
+			}
+		});
+
+		await user.click(trigger);
+		expect(returnedId).toBe(0);
+		expect(toastState.toasts[0]?.id).toBe(0);
+	});
+});

--- a/src/tests/upstream-sync.spec.ts
+++ b/src/tests/upstream-sync.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it } from 'vitest';
 import PropsToastTest from './PropsToastTest.svelte';
+import MultiToasterTest from './MultiToasterTest.svelte';
 import TestIcon from './TestIcon.svelte';
 import { render, waitFor } from '@testing-library/svelte';
 import { userEvent } from '@testing-library/user-event';
@@ -209,5 +210,77 @@ describe('upstream sonner#777 parity', () => {
 		await user.click(trigger);
 		expect(returnedId).toBe(0);
 		expect(toastState.toasts[0]?.id).toBe(0);
+	});
+
+	it('routes toasts to the toaster matching their toasterId', async () => {
+		const user = userEvent.setup();
+		const { getByTestId } = render(MultiToasterTest, {
+			props: {
+				cb: (toast: typeof import('$lib/toast-state.svelte.js').toast) => {
+					toast('For the default toaster');
+					toast('For the named toaster', { toasterId: 'secondary' });
+				}
+			}
+		});
+
+		await user.click(getByTestId('trigger'));
+
+		const defaultToaster = getByTestId('default-toaster');
+		const namedToaster = getByTestId('named-toaster');
+
+		expect(defaultToaster).toHaveTextContent('For the default toaster');
+		expect(defaultToaster).not.toHaveTextContent('For the named toaster');
+		expect(namedToaster).toHaveTextContent('For the named toaster');
+		expect(namedToaster).not.toHaveTextContent('For the default toaster');
+	});
+
+	it('dismisses toasts across all toasters with toast.dismiss()', async () => {
+		const user = userEvent.setup();
+		const { getByTestId } = render(MultiToasterTest, {
+			props: {
+				cb: (toast: typeof import('$lib/toast-state.svelte.js').toast) => {
+					toast('Default toast');
+					toast('Named toast', { toasterId: 'secondary' });
+					setTimeout(() => toast.dismiss(), 100);
+				}
+			}
+		});
+
+		await user.click(getByTestId('trigger'));
+		expect(getByTestId('default-toaster')).toHaveTextContent('Default toast');
+
+		await sleep(500);
+		expect(
+			document.querySelectorAll('[data-sonner-toast]:not([data-removed="true"])').length
+		).toBe(0);
+	});
+
+	it('uses the gap prop in the offset math', async () => {
+		const { user, trigger, container } = setup({
+			cb: (toast) => {
+				toast('First toast');
+				toast('Second toast');
+			},
+			gap: 20
+		});
+
+		await user.click(trigger);
+
+		const offsets = Array.from(
+			container.querySelectorAll<HTMLElement>('[data-sonner-toast]')
+		).map((el) => el.style.getPropertyValue('--offset'));
+
+		// jsdom measures zero heights, so the non-front toast's offset is exactly the gap
+		expect(offsets).toContain('20px');
+	});
+
+	it('shows the close button when set via toastOptions', async () => {
+		const { user, trigger, container } = setup({
+			cb: (toast) => toast('With close button'),
+			toastOptions: { closeButton: true }
+		});
+
+		await user.click(trigger);
+		expect(container.querySelector('[data-close-button]')).not.toBeNull();
 	});
 });

--- a/src/tests/upstream-sync.spec.ts
+++ b/src/tests/upstream-sync.spec.ts
@@ -168,9 +168,7 @@ describe('upstream sonner#777 parity', () => {
 		await user.click(trigger);
 		await sleep(500);
 		expect(getByText('Remounted toast')).toBeVisible();
-		expect(
-			document.querySelector('[data-sonner-toast][data-removed="true"]')
-		).toBeNull();
+		expect(document.querySelector('[data-sonner-toast][data-removed="true"]')).toBeNull();
 	});
 
 	it('treats an id reused after a close-button dismissal as a new toast', async () => {

--- a/src/tests/upstream-sync.spec.ts
+++ b/src/tests/upstream-sync.spec.ts
@@ -130,6 +130,74 @@ describe('upstream sonner#777 parity', () => {
 		);
 	});
 
+	it('shows a toast created before the Toaster mounts', async () => {
+		toast('Created before mount');
+
+		const { getByText } = setup({ cb: () => {} });
+
+		await waitFor(() => expect(getByText('Created before mount')).toBeVisible());
+	});
+
+	it('does not leak props into a new toast reusing a dismissed toast id', async () => {
+		const { user, trigger, getByText, queryByText } = setup({
+			cb: (toast) => {
+				const id = toast('With action', {
+					action: { label: 'Undo', onClick: () => {} }
+				});
+				toast.dismiss(id);
+				toast('Without action', { id });
+			}
+		});
+
+		await user.click(trigger);
+		await waitFor(() => expect(getByText('Without action')).toBeVisible());
+		expect(queryByText('Undo')).toBeNull();
+	});
+
+	it('keeps a toast recreated during the exit animation window on screen', async () => {
+		const { user, trigger, getByText } = setup({
+			cb: (toast) => {
+				const id = toast('Original toast');
+				toast.dismiss(id);
+				// recreate while the 200ms exit-animation removal is still pending
+				setTimeout(() => toast('Remounted toast', { id }), 100);
+			}
+		});
+
+		await user.click(trigger);
+		await sleep(500);
+		expect(getByText('Remounted toast')).toBeVisible();
+		expect(
+			document.querySelector('[data-sonner-toast][data-removed="true"]')
+		).toBeNull();
+	});
+
+	it('treats an id reused after a close-button dismissal as a new toast', async () => {
+		let onDismissCalls = 0;
+		let toastId: string | number;
+		const { user, trigger, container, getByText, queryByText } = setup({
+			cb: (toast) => {
+				toastId = toast('Closable toast', {
+					closeButton: true,
+					action: { label: 'Undo', onClick: () => {} },
+					onDismiss: () => onDismissCalls++
+				});
+			}
+		});
+
+		await user.click(trigger);
+		expect(getByText('Closable toast')).toBeVisible();
+
+		const closeButton = container.querySelector<HTMLButtonElement>('[data-close-button]');
+		await user.click(closeButton!);
+		expect(onDismissCalls).toBe(1);
+
+		toast('Recreated toast', { id: toastId! });
+		await waitFor(() => expect(getByText('Recreated toast')).toBeVisible());
+		expect(queryByText('Undo')).toBeNull();
+		expect(onDismissCalls).toBe(1);
+	});
+
 	it('keeps an explicit id of 0 in toast.custom()', async () => {
 		let returnedId: string | number | undefined;
 		const { user, trigger } = setup({

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,10 +1,9 @@
 import adapter from '@sveltejs/adapter-auto';
-import { sveltePreprocess } from 'svelte-preprocess';
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-	preprocess: [vitePreprocess(), sveltePreprocess({ globalStyle: true })],
+	preprocess: [vitePreprocess()],
 	kit: {
 		adapter: adapter()
 	}

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "passed",
+  "failedTests": []
+}

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,4 +1,0 @@
-{
-  "status": "passed",
-  "failedTests": []
-}

--- a/tests/sonner-parity.test.ts
+++ b/tests/sonner-parity.test.ts
@@ -1,0 +1,125 @@
+import { expect, test } from '@playwright/test';
+
+// Browser-level ports of the regression tests added in emilkowalski/sonner#777,
+// driven by the dedicated /test route.
+test.describe.configure({ mode: 'parallel' });
+
+test.beforeEach(async ({ page }) => {
+	await page.goto('/test');
+});
+
+test('classNames.default is only applied to toasts without a type', async ({ page }) => {
+	await page.getByTestId('default-button').click();
+	await expect(page.locator('[data-sonner-toast]')).toHaveClass(/default-toast-classname/);
+
+	await page.getByTestId('success').click();
+	const successToast = page.locator('[data-sonner-toast][data-type="success"]');
+	await expect(successToast).toHaveClass(/success-toast-classname/);
+	await expect(successToast).not.toHaveClass(/default-toast-classname/);
+});
+
+test('custom icon is only rendered once in a promise toast', async ({ page }) => {
+	await page.getByTestId('promise-custom-icon').click();
+	await expect(page.getByText('Loading...')).toHaveCount(1);
+
+	await expect(page.getByText('Loaded')).toHaveCount(1);
+	await expect(page.getByTestId('custom-success-icon')).toHaveCount(1);
+});
+
+test('icons are hidden from assistive technology', async ({ page }) => {
+	await page.getByTestId('success').click();
+	await expect(page.locator('[data-sonner-toast] [data-icon] svg')).toHaveAttribute(
+		'aria-hidden',
+		'true'
+	);
+});
+
+test('toast created before the Toaster mounts is still shown', async ({ page }) => {
+	await page.goto('/test?toastOnMount');
+	await expect(page.getByText('Toast rendered on mount')).toHaveCount(1);
+});
+
+test('toast recreated right after being dismissed stays on screen', async ({ page }) => {
+	await page.getByTestId('dismiss-and-recreate').click();
+
+	// The pending removal must not take the newly created toast down with it
+	await page.waitForTimeout(500);
+	await expect(page.getByText('Remounted toast')).toHaveCount(1);
+});
+
+test('toast is not dismissed by a fast swipe in a direction that is not allowed', async ({
+	page
+}) => {
+	await page.goto('/test?position=top-center&swipeDirections=top,right');
+	await page.getByTestId('default-button').click();
+
+	const toast = page.locator('[data-sonner-toast]');
+	// hover() waits for the enter animation to finish, so the toast is where
+	// boundingBox() says it is before the pointer gestures start
+	await toast.hover();
+	const box = await toast.boundingBox();
+	if (!box) throw new Error('Toast not rendered');
+
+	// Fast flick to the left; `left` is not in swipeDirections
+	await page.mouse.down();
+	await page.mouse.move(box.x - 200, box.y + box.height / 2, { steps: 5 });
+	await page.mouse.up();
+
+	// Long enough for the exit animation to have removed the toast if it had been dismissed
+	await page.waitForTimeout(500);
+	await expect(toast).toHaveCount(1);
+});
+
+test('toast is dismissed by a fast swipe in an allowed direction', async ({ page }) => {
+	await page.goto('/test?position=top-center&swipeDirections=top,right');
+	await page.getByTestId('default-button').click();
+
+	const toast = page.locator('[data-sonner-toast]');
+	await toast.hover();
+	const box = await toast.boundingBox();
+	if (!box) throw new Error('Toast not rendered');
+
+	await page.mouse.down();
+	await page.mouse.move(box.x + box.width + 200, box.y + box.height / 2, { steps: 5 });
+	await page.mouse.up();
+
+	// Well below the 4s auto-close, so this only passes if the swipe dismissed it
+	await expect(toast).toHaveCount(0, { timeout: 2000 });
+});
+
+test('description fills the width of the toast', async ({ page }) => {
+	await page.getByTestId('component-description').click();
+
+	const description = await page.getByTestId('wide-description').boundingBox();
+	const toast = await page.locator('[data-sonner-toast]').boundingBox();
+	if (!description || !toast) throw new Error('Toast not rendered');
+
+	// Full width minus the padding and the icon-less content offset
+	expect(description.width).toBeGreaterThan(toast.width - 60);
+});
+
+test('action button stays right aligned', async ({ page }) => {
+	await page.getByTestId('action').click();
+
+	const button = await page.locator('[data-button]').boundingBox();
+	const toast = await page.locator('[data-sonner-toast]').boundingBox();
+	if (!button || !toast) throw new Error('Toast not rendered');
+
+	expect(button.x + button.width).toBeGreaterThan(toast.x + toast.width - 30);
+});
+
+test('toasts are routed to the toaster matching their toasterId', async ({ page }) => {
+	await page.goto('/test?secondToaster');
+
+	await page.getByTestId('toast-to-secondary').click();
+	await page.getByTestId('default-button').click();
+
+	// The secondary toaster sits top-left, the default one bottom-right
+	const secondaryList = page.locator('[data-sonner-toaster][data-y-position="top"]');
+	const defaultList = page.locator('[data-sonner-toaster][data-y-position="bottom"]');
+
+	await expect(secondaryList.getByText('Secondary toast')).toHaveCount(1);
+	await expect(secondaryList.getByText('My default toast')).toHaveCount(0);
+	await expect(defaultList.getByText('My default toast')).toHaveCount(1);
+	await expect(defaultList.getByText('Secondary toast')).toHaveCount(0);
+});

--- a/tests/sonner-parity.test.ts
+++ b/tests/sonner-parity.test.ts
@@ -87,6 +87,23 @@ test('toast is dismissed by a fast swipe in an allowed direction', async ({ page
 	await expect(toast).toHaveCount(0, { timeout: 2000 });
 });
 
+test('toast is dismissed by a fast flick below the distance threshold', async ({ page }) => {
+	await page.goto('/test?position=top-center&swipeDirections=right');
+	await page.getByTestId('default-button').click();
+
+	const toast = page.locator('[data-sonner-toast]');
+	await toast.hover();
+	const box = await toast.boundingBox();
+	if (!box) throw new Error('Toast not rendered');
+
+	await page.mouse.down();
+	await page.mouse.move(box.x + box.width / 2 + 20, box.y + box.height / 2);
+	await page.mouse.up();
+
+	// The 20px movement is below SWIPE_THRESHOLD, so only velocity can dismiss it.
+	await expect(toast).toHaveCount(0, { timeout: 2000 });
+});
+
 test('description fills the width of the toast', async ({ page }) => {
 	await page.getByTestId('component-description').click();
 

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -37,11 +37,17 @@ test('render custom component in toast', async ({ page }) => {
 
 test('toast is removed after swiping down', async ({ page }) => {
 	await page.getByTestId('default-button').click();
-	await page.hover('[data-sonner-toast]');
+	const toast = page.locator('[data-sonner-toast]');
+	await toast.hover();
+	const box = await toast.boundingBox();
+	if (!box) throw new Error('Toast not rendered');
 	await page.mouse.down();
-	await page.mouse.move(0, 800);
+	// straight down, so the gesture locks to the y axis (down is an allowed
+	// direction for a bottom-positioned toast)
+	await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2 + 300, { steps: 5 });
 	await page.mouse.up();
-	await expect(page.locator('[data-sonner-toast]')).toHaveCount(0);
+	// Well below the 4s auto-close, so this only passes if the swipe dismissed it
+	await expect(toast).toHaveCount(0, { timeout: 2000 });
 });
 
 test('toast is not removed when hovered', async ({ page }) => {


### PR DESCRIPTION
Ports the fix batch from emilkowalski/sonner#777 to the Svelte implementation, plus the Svelte-specific bugs found while auditing against it.

- Fixes #120 — toasts created before the `<Toaster />` mounts are no longer lost
- Fixes #169 — styles are now a native Svelte 5 `:global` block instead of svelte-preprocess `<style global>`, so the published component compiles with the latest `@sveltejs/vite-plugin-svelte` (and `svelte-preprocess` is dropped entirely)
- Fixes #180 — toasts can target a specific toaster via `<Toaster id="..." />` and `toast(..., { toasterId })`
- Fixes #187 — the `gap` prop is used in the offset math instead of a hardcoded value
- Fixes #104 — passing `swipeDirections={[]}` disables swiping (and the prop is now actually passed down from the Toaster; it was dead before)
- Ports emilkowalski/sonner#718 — custom icons are no longer rendered twice in promise toasts; the loader stays mounted after settling so it can animate out
- Ports emilkowalski/sonner#762 — a fast flick no longer dismisses a toast in a direction that is not in `swipeDirections`
- Ports emilkowalski/sonner#713 — decorative SVG icons are hidden from assistive technology
- Ports emilkowalski/sonner#692 — a new toast reusing the id of a dismissed toast no longer inherits its props (e.g. a leftover `action`)
- Ports emilkowalski/sonner#592 — a toast recreated right after being dismissed is no longer removed by the pending dismissal
- Ports emilkowalski/sonner#683 — toast content is no longer limited to the width of its text
- `toast.custom()` keeps an explicit id of `0`
- `toastOptions.closeButton` is now honored
- `--front-toast-height` no longer renders `undefinedpx`, and a `& 100` → `* 100` typo in the height measurement is fixed
- A fast flick below the 45px distance threshold now dismisses: `dragStartTime` was never recorded, so the velocity check could never pass
- Recreating a dismissed toast id in the same tick resets the auto-close timer instead of inheriting the old toast's shorter one
- Height entries stay in newest-first order when several toasts mount together (same-tick creates, or toasts created before the Toaster mounts), keeping offsets and `--front-toast-height` correct
- A toast revived mid-exit fully resets its gesture state (swipe axis lock, drag origin, swipe-amount CSS vars)
- README documents multiple toasters (`<Toaster id />` + `toasterId`)

Already correct here, covered with tests only: `classNames.default` applies only to untyped toasts (upstream's #744), and `toast()` / `toast.custom()` clear the loading state of a toast with the same id (upstream's #401 / #652). Upstream's history trimming (#729) and `@types/react` peer dep (#766) don't apply to this port.

### Notes

- Upstream's subscriber-based fixes are translated to the `$state` singleton model: removal bookkeeping lives in `ToastState` (`pendingRemovals`, cancelled by `create()`), and `Toast.svelte` revives its local exit state when the keyed each reuses the component instance for a recreated id.
- Breaking-ish: an `id` passed to `<Toaster />` now identifies the toaster (upstream semantics) instead of falling through to the `<ol>` element.
- A toast revived mid-exit-animation fades back instead of replaying the enter animation (keyed-reuse trade-off vs React's fresh element).

### Tests

- Unit (vitest): `src/tests/toaster.spec.ts` and `src/tests/toast-lifecycle.spec.ts` cover the fixes above; 20 tests passing.
- Browser (Playwright): `tests/sonner-parity.test.ts` ports the regression tests upstream added in #777, driven by a dedicated `/test` route with query params (`?position=top-center&swipeDirections=top,right`, `?toastOnMount`, `?secondToaster`); 18 tests passing. The pre-existing swipe test was rewritten to perform a real downward swipe, and swipe assertions are capped at 2s so the 4s auto-close can never rescue a failed gesture.
- Playwright's `test-results/` output is untracked and gitignored.

Supersedes #183, #189, #195, #197.
